### PR TITLE
fix: give the redux store a valid reducer

### DIFF
--- a/frontend/src/stores/store.ts
+++ b/frontend/src/stores/store.ts
@@ -1,8 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+// Placeholder reducer so the store has a valid reducer map before any feature
+// slices exist (configureStore throws on an empty `reducer` object). Remove
+// this entry once the first real feature slice is added below.
+const placeholderReducer = (state: Record<string, never> = {}) => state;
+
 export const makeStore = () => {
   return configureStore({
-    reducer: {},
+    reducer: {
+      placeholder: placeholderReducer,
+    },
   });
 };
 


### PR DESCRIPTION
Fixes a runtime crash where the app failed to load with "Store does not have a valid reducer".

Since `AppProvider` now mounts the Redux store, `makeStore` runs on load, and `configureStore` throws when given an empty `reducer` map. This adds a placeholder reducer so the store initializes cleanly, with a comment to remove it once the first real feature slice is added.

Verified locally: `/en` loads with HTTP 200 and no reducer error, and tests, lint, and the build all pass.
