### PR TITLE
feat: populate home page with invoice features

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,9 +1,20 @@
 {
-  "HomePage": {
-    "title": "Hello world!",
-    "about": "Go to the about page"
-  },
   "MainMenu": {
-    "profileImageAlt": "Profile image"
+    "profileImageAlt": "Profile image",
+    "switchToDark": "Switch to dark mode",
+    "switchToLight": "Switch to light mode"
+  },
+  "Dashboard": {
+    "title": "Invoices",
+    "totalMobile": "{count} invoices",
+    "totalDesktop": "There are {count} total invoices",
+    "filterMobile": "Filter",
+    "filterDesktop": "Filter by status",
+    "newInvoiceMobile": "New",
+    "newInvoiceDesktop": "New Invoice",
+    "statusDraft": "Draft",
+    "statusPending": "Pending",
+    "statusPaid": "Paid",
+    "due": "Due"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
     "dev:n": "next dev",

--- a/frontend/src/app/[locale]/home-view.tsx
+++ b/frontend/src/app/[locale]/home-view.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import MainMenu from '@/components/layouts/main-menu/main-menu';
+import InvoiceBar from '@/features/invoices/components/invoice-bar/invoice-bar';
+import type { FilterState } from '@/features/invoices/components/invoice-bar/invoice-bar.types';
+import Invoice from '@/features/invoices/components/invoice/invoice';
+import { InvoiceStatus } from '@/features/invoices/types/invoice';
+import { useDarkMode } from '@/hooks/use-dark-mode';
+
+interface SampleInvoice {
+  invoiceId: string;
+  billingName: string;
+  invoiceDueDate: string;
+  invoiceAmountDue: number;
+  invoiceStatus: InvoiceStatus;
+}
+
+// Sample data stands in for the (not yet built) data layer; when an API is
+// added this should come from `features/invoices/api`.
+const SAMPLE_INVOICES: SampleInvoice[] = [
+  {
+    invoiceId: 'RT3080',
+    billingName: 'Jensen Huang',
+    invoiceDueDate: '19 Aug 2021',
+    invoiceAmountDue: 1800.9,
+    invoiceStatus: InvoiceStatus.PAID,
+  },
+  {
+    invoiceId: 'XM9141',
+    billingName: 'Alex Grim',
+    invoiceDueDate: '20 Sep 2021',
+    invoiceAmountDue: 556.0,
+    invoiceStatus: InvoiceStatus.PENDING,
+  },
+  {
+    invoiceId: 'RG0314',
+    billingName: 'John Morrison',
+    invoiceDueDate: '01 Oct 2021',
+    invoiceAmountDue: 14002.33,
+    invoiceStatus: InvoiceStatus.DRAFT,
+  },
+];
+
+const STATUS_TO_FILTER_KEY: Record<InvoiceStatus, keyof FilterState> = {
+  [InvoiceStatus.DRAFT]: 'draft',
+  [InvoiceStatus.PENDING]: 'pending',
+  [InvoiceStatus.PAID]: 'paid',
+};
+
+const HomeView = () => {
+  const t = useTranslations('Dashboard');
+  const tMenu = useTranslations('MainMenu');
+  const { theme, toggleTheme } = useDarkMode();
+  const [filters, setFilters] = useState<FilterState>({
+    draft: false,
+    pending: false,
+    paid: false,
+  });
+
+  const statusLabels: Record<InvoiceStatus, string> = {
+    [InvoiceStatus.DRAFT]: t('statusDraft'),
+    [InvoiceStatus.PENDING]: t('statusPending'),
+    [InvoiceStatus.PAID]: t('statusPaid'),
+  };
+
+  const noFilterActive = !filters.draft && !filters.pending && !filters.paid;
+  const visibleInvoices = SAMPLE_INVOICES.filter(
+    (invoice) => noFilterActive || filters[STATUS_TO_FILTER_KEY[invoice.invoiceStatus]]
+  );
+
+  return (
+    <div className="min-h-screen lg:pl-[103px]">
+      <MainMenu
+        darkmode={theme}
+        darkmodeBtn={{ darkAria: tMenu('switchToDark'), lightAria: tMenu('switchToLight') }}
+        darkmodeToggle={toggleTheme}
+        profile={{ profileImageAlt: tMenu('profileImageAlt') }}
+      />
+      <main className="mx-auto flex max-w-[730px] flex-col gap-y-8 px-6 py-8 md:py-12 lg:py-16">
+        <InvoiceBar
+          filters={filters}
+          filterStatusBtn={{ mobile: t('filterMobile'), desktop: t('filterDesktop') }}
+          invoiceBarTitle={t('title')}
+          newInvoiceBtn={{ mobile: t('newInvoiceMobile'), desktop: t('newInvoiceDesktop') }}
+          newInvoiceHandler={() => {}}
+          setFilters={setFilters}
+          filterStatusText={{
+            draft: t('statusDraft'),
+            pending: t('statusPending'),
+            paid: t('statusPaid'),
+          }}
+          totalInvoicesText={{
+            mobile: t('totalMobile', { count: SAMPLE_INVOICES.length }),
+            desktop: t('totalDesktop', { count: SAMPLE_INVOICES.length }),
+          }}
+        />
+        <ul className="flex flex-col gap-y-4">
+          {visibleInvoices.map((invoice) => (
+            <li key={invoice.invoiceId}>
+              <Invoice
+                {...invoice}
+                dueText={t('due')}
+                invoiceStatusText={statusLabels[invoice.invoiceStatus]}
+              />
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+};
+
+export default HomeView;

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
+import HomeView from './home-view';
 
 export default function Home() {
-  return <div>hello world</div>;
+  return <HomeView />;
 }

--- a/frontend/src/components/layouts/main-menu/main-menu.stories.tsx
+++ b/frontend/src/components/layouts/main-menu/main-menu.stories.tsx
@@ -3,7 +3,7 @@ import MainMenu from '@/components/layouts/main-menu/main-menu';
 import { DARK_MODE } from '@/config/constants';
 
 const meta = {
-  title: 'Molecules/Main Menu',
+  title: 'Layouts/Main Menu',
   component: MainMenu,
   tags: ['autodocs'],
   parameters: {

--- a/frontend/src/components/ui/button/button.stories.tsx
+++ b/frontend/src/components/ui/button/button.stories.tsx
@@ -3,7 +3,7 @@ import { fn } from 'storybook/test';
 import Button from '@/components/ui/button/button';
 
 const meta = {
-  title: 'Atoms/Button',
+  title: 'UI/Button',
   component: Button,
   tags: ['autodocs'],
   args: { onClick: fn() },

--- a/frontend/src/components/ui/checkbox/checkbox.stories.tsx
+++ b/frontend/src/components/ui/checkbox/checkbox.stories.tsx
@@ -3,7 +3,7 @@ import type { StoryObj } from '@storybook/nextjs';
 import Checkbox from '@/components/ui/checkbox/checkbox';
 
 const meta = {
-  title: 'Atoms/Checkbox',
+  title: 'UI/Checkbox',
   component: Checkbox,
   tags: ['autodocs'],
 };

--- a/frontend/src/components/ui/icon/icon.stories.tsx
+++ b/frontend/src/components/ui/icon/icon.stories.tsx
@@ -3,7 +3,7 @@ import type { StoryObj } from '@storybook/nextjs';
 import Icon from '@/components/ui/icon/icon';
 
 const meta = {
-  title: 'Atoms/Icon',
+  title: 'UI/Icon',
   component: Icon,
   tags: ['autodocs'],
 };

--- a/frontend/src/components/ui/rich-text/rich-text.stories.tsx
+++ b/frontend/src/components/ui/rich-text/rich-text.stories.tsx
@@ -3,7 +3,7 @@ import type { StoryObj } from '@storybook/nextjs';
 import RichText from '@/components/ui/rich-text/rich-text';
 
 const meta = {
-  title: 'Atoms/Rich Text',
+  title: 'UI/Rich Text',
   component: RichText,
   tags: ['autodocs'],
 };

--- a/frontend/src/components/ui/text/text.stories.tsx
+++ b/frontend/src/components/ui/text/text.stories.tsx
@@ -3,7 +3,7 @@ import type { StoryObj } from '@storybook/nextjs';
 import Text from '@/components/ui/text/text';
 
 const meta = {
-  title: 'Atoms/Text',
+  title: 'UI/Text',
   component: Text,
   tags: ['autodocs'],
 };

--- a/frontend/src/features/invoices/components/invoice-bar/invoice-bar.stories.tsx
+++ b/frontend/src/features/invoices/components/invoice-bar/invoice-bar.stories.tsx
@@ -3,7 +3,7 @@ import type { StoryObj } from '@storybook/nextjs';
 import InvoiceBar from '@/features/invoices/components/invoice-bar/invoice-bar';
 
 const meta = {
-  title: 'Molecules/Invoice Bar',
+  title: 'Features/Invoices/Invoice Bar',
   component: InvoiceBar,
   tags: ['autodocs'],
 };

--- a/frontend/src/features/invoices/components/invoice/invoice.stories.tsx
+++ b/frontend/src/features/invoices/components/invoice/invoice.stories.tsx
@@ -4,7 +4,7 @@ import Invoice from '@/features/invoices/components/invoice/invoice';
 import { InvoiceStatus } from '../../types/invoice';
 
 const meta = {
-  title: 'Molecules/Invoice',
+  title: 'Features/Invoices/Invoice',
   component: Invoice,
   tags: ['autodocs'],
 };

--- a/frontend/src/hooks/use-dark-mode.ts
+++ b/frontend/src/hooks/use-dark-mode.ts
@@ -1,16 +1,31 @@
 'use client';
+import { useSyncExternalStore } from 'react';
 import { useTheme } from 'next-themes';
 
+const emptySubscribe = () => () => {};
+
 export const useDarkMode = () => {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+
+  // Hydration-safe mount flag: `false` on the server and during the initial
+  // client render, `true` afterwards. This keeps the first client render
+  // identical to the server render (avoiding a hydration mismatch on
+  // theme-dependent UI) without calling setState inside an effect.
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
+
+  const theme = mounted ? resolvedTheme : undefined;
+
+  const toggleTheme = () => {
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+  };
 
   const toggleDarkMode = (isDarkMode: boolean) => {
     setTheme(isDarkMode ? 'dark' : 'light');
   };
 
-  const toggleTheme = () => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
-  };
-
-  return { theme, toggleDarkMode, toggleTheme };
+  return { theme, toggleTheme, toggleDarkMode };
 };


### PR DESCRIPTION
Replaces the placeholder home page with the ready features and includes related frontend fixes.

**Home page** (`feat`)
- Renders MainMenu, InvoiceBar, and a list of Invoice components with sample data, wired up with dark-mode toggling and working status filters.
- Adds the required UI strings to `messages/en.json` under a Dashboard namespace. Sample invoice data stands in for a future `features/invoices/api` data layer.

**Storybook** (`chore`)
- Renames story titles from atomic terms to bulletproof nomenclature: `Atoms/*` becomes `UI/*`, invoice stories move under `Features/Invoices/*`, and MainMenu moves under `Layouts/*`.

**Dark mode** (`fix`)
- Uses the resolved theme with a hydration-safe mount flag (`useSyncExternalStore`) so the icon and aria label no longer mismatch on hydration, and the toggle flips on the first click.

**Tailwind** (`chore`)
- Sets `"type": "module"` so `tailwind.config.ts` no longer triggers the module-type reparse warning. Verified against build, tests, lint, Storybook, and a production server start.

All 60 tests and 14 snapshots pass, lint is clean, and both the dev and production servers serve the page with HTTP 200.
