### PR TITLE
feat(invoices): add invoice details view

### DIFF
--- a/frontend/src/features/invoices/components/invoice-details/invoice-details.stories.tsx
+++ b/frontend/src/features/invoices/components/invoice-details/invoice-details.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import InvoiceDetails from '@/features/invoices/components/invoice-details/invoice-details';
+import { InvoiceStatus } from '@/features/invoices/types/invoice';
+
+const meta = {
+  title: 'Features/Invoices/Invoice Details',
+  component: InvoiceDetails,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-[730px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InvoiceDetails>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const labels = {
+  goBack: 'Go back',
+  status: 'Status',
+  statusText: 'Pending',
+  edit: 'Edit',
+  delete: 'Delete',
+  markAsPaid: 'Mark as Paid',
+  billTo: 'Bill To',
+  sentTo: 'Sent to',
+  invoiceDate: 'Invoice Date',
+  paymentDue: 'Payment Due',
+  itemName: 'Item Name',
+  quantity: 'QTY.',
+  price: 'Price',
+  total: 'Total',
+  amountDue: 'Amount Due',
+};
+
+const baseArgs = {
+  invoiceId: 'XM9141',
+  description: 'Graphic Design',
+  invoiceStatus: InvoiceStatus.PENDING,
+  invoiceDate: '21 Aug 2021',
+  paymentDue: '20 Sep 2021',
+  senderAddress: {
+    street: '19 Union Terrace',
+    city: 'London',
+    postCode: 'E1 3EZ',
+    country: 'United Kingdom',
+  },
+  clientName: 'Alex Grim',
+  clientEmail: 'alexgrim@mail.com',
+  clientAddress: {
+    street: '84 Church Way',
+    city: 'Bradford',
+    postCode: 'BD1 9PB',
+    country: 'United Kingdom',
+  },
+  items: [
+    { name: 'Banner Design', quantity: 1, price: 156 },
+    { name: 'Email Design', quantity: 2, price: 200 },
+  ],
+  invoiceAmountDue: 556,
+  localeAmountDue: 'en' as const,
+  labels,
+};
+
+export const Pending: Story = {
+  args: baseArgs,
+};
+
+export const Paid: Story = {
+  args: {
+    ...baseArgs,
+    invoiceStatus: InvoiceStatus.PAID,
+    labels: { ...labels, statusText: 'Paid' },
+  },
+};
+
+export const Draft: Story = {
+  args: {
+    ...baseArgs,
+    invoiceStatus: InvoiceStatus.DRAFT,
+    labels: { ...labels, statusText: 'Draft' },
+  },
+};

--- a/frontend/src/features/invoices/components/invoice-details/invoice-details.tsx
+++ b/frontend/src/features/invoices/components/invoice-details/invoice-details.tsx
@@ -1,0 +1,236 @@
+/**
+ * @name InvoiceDetails
+ * @author Tyrell Curry <tyrellcurryio@gmail.com>
+ *
+ * Full "view invoice" page content: go-back link, status/actions bar and the
+ * invoice detail card (meta, line items and amount due). Presentation only —
+ * all copy, data and handlers arrive via props.
+ *
+ * @param props - see {@link IInvoiceDetailsProps}
+ *
+ * @returns {JSX.Element}
+ */
+import { JSX } from 'react';
+import classNames from 'classnames';
+import Button from '@/components/ui/button/button';
+import Text from '@/components/ui/text/text';
+import {
+  IInvoiceDetailsProps,
+  InvoiceAddress,
+} from '@/features/invoices/components/invoice-details/invoice-details.types';
+import {
+  formatInvoiceAmount,
+  getCurrencySymbol,
+} from '@/features/invoices/utils/format-invoice-amount';
+import { getInvoiceStatusStyles } from '@/features/invoices/utils/get-invoice-status-styles';
+import { getLineItemTotal } from '@/features/invoices/utils/get-line-item-total';
+
+const AddressBlock = ({
+  address,
+  className,
+}: {
+  address: InvoiceAddress;
+  className?: string;
+}): JSX.Element => (
+  <div
+    className={classNames('text-gray-07 dark:text-gray-05 flex flex-col leading-[18px]', className)}
+  >
+    <Text tag={'span'}>{address.street}</Text>
+    <Text tag={'span'}>{address.city}</Text>
+    <Text tag={'span'}>{address.postCode}</Text>
+    <Text tag={'span'}>{address.country}</Text>
+  </div>
+);
+
+const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
+  const {
+    invoiceId,
+    description,
+    invoiceStatus,
+    invoiceDate,
+    paymentDue,
+    senderAddress,
+    clientName,
+    clientEmail,
+    clientAddress,
+    items,
+    invoiceAmountDue,
+    localeAmountDue = 'en',
+    labels,
+    onGoBack,
+    onEdit,
+    onDelete,
+    onMarkAsPaid,
+  } = props;
+
+  const currency = getCurrencySymbol(localeAmountDue);
+  const statusStyles = getInvoiceStatusStyles(invoiceStatus);
+
+  const actions = (
+    <div className="flex items-center gap-x-2">
+      <Button label={labels.edit} variant="secondary" onClick={onEdit} />
+      <Button label={labels.delete} variant="danger" onClick={onDelete} />
+      <Button label={labels.markAsPaid} variant="primary" onClick={onMarkAsPaid} />
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-y-6">
+      <Button
+        className="flex items-center gap-x-6 w-fit font-bold text-gray-08 dark:text-white"
+        iconLeft={'chevron-right'}
+        iconLeftClassName="rotate-180 shrink-0"
+        label={labels.goBack}
+        variant="custom"
+        onClick={onGoBack}
+      />
+
+      {/* Status / actions bar */}
+      <div className="flex flex-col gap-y-6 md:flex-row md:items-center md:justify-between rounded-lg bg-white px-6 py-5 md:px-8 drop-shadow-lg dark:bg-blue-03">
+        <div className="flex items-center justify-between gap-x-4 md:justify-start md:gap-x-4">
+          <Text className="text-gray-07b dark:text-gray-05" tag={'span'}>
+            {labels.status}
+          </Text>
+          <div
+            className={classNames(
+              'flex items-center justify-center gap-x-1.5 rounded-md px-[18px] py-3 leading-none w-[104px]',
+              statusStyles.badge
+            )}
+          >
+            <div className={classNames('w-2 h-2 rounded-full', statusStyles.dot)} />
+            <Text className="font-bold" tag={'span'}>
+              {labels.statusText}
+            </Text>
+          </div>
+        </div>
+        <div className="hidden md:block">{actions}</div>
+      </div>
+
+      {/* Invoice detail card */}
+      <div className="rounded-lg bg-white p-6 md:p-12 drop-shadow-lg dark:bg-blue-03">
+        {/* Header: id + description / sender address */}
+        <div className="flex flex-col gap-y-8 md:flex-row md:justify-between">
+          <div>
+            <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
+              <Text className="text-gray-06" tag={'span'}>
+                #
+              </Text>
+              {invoiceId}
+            </Text>
+            <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
+              {description}
+            </Text>
+          </div>
+          <AddressBlock address={senderAddress} className="md:text-right" />
+        </div>
+
+        {/* Meta: dates / bill to / sent to */}
+        <div className="mt-8 grid grid-cols-2 gap-y-8 md:mt-11 md:grid-cols-3">
+          <div className="flex flex-col gap-y-8">
+            <div className="flex flex-col gap-y-3">
+              <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
+                {labels.invoiceDate}
+              </Text>
+              <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
+                {invoiceDate}
+              </Text>
+            </div>
+            <div className="flex flex-col gap-y-3">
+              <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
+                {labels.paymentDue}
+              </Text>
+              <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
+                {paymentDue}
+              </Text>
+            </div>
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
+              {labels.billTo}
+            </Text>
+            <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
+              {clientName}
+            </Text>
+            <AddressBlock address={clientAddress} className="mt-1" />
+          </div>
+          <div className="flex flex-col gap-y-3">
+            <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
+              {labels.sentTo}
+            </Text>
+            <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
+              {clientEmail}
+            </Text>
+          </div>
+        </div>
+
+        {/* Line items */}
+        <div className="mt-11 overflow-hidden rounded-lg">
+          <div className="bg-gray-05b p-6 md:p-8 dark:bg-blue-04">
+            <div className="hidden grid-cols-[2fr_0.5fr_1fr_1fr] gap-x-4 md:grid">
+              <Text className="text-gray-07 dark:text-gray-05" tag={'span'}>
+                {labels.itemName}
+              </Text>
+              <Text className="text-gray-07 text-center dark:text-gray-05" tag={'span'}>
+                {labels.quantity}
+              </Text>
+              <Text className="text-gray-07 text-right dark:text-gray-05" tag={'span'}>
+                {labels.price}
+              </Text>
+              <Text className="text-gray-07 text-right dark:text-gray-05" tag={'span'}>
+                {labels.total}
+              </Text>
+            </div>
+            <ul className="flex flex-col gap-y-6 md:gap-y-8 md:mt-8">
+              {items.map((item) => (
+                <li
+                  className="grid grid-cols-2 items-center md:grid-cols-[2fr_0.5fr_1fr_1fr] md:gap-x-4"
+                  key={item.name}
+                >
+                  <Text className="font-bold text-gray-08 dark:text-white" tag={'span'}>
+                    {item.name}
+                  </Text>
+                  <Text
+                    className="text-gray-07 font-bold row-start-2 dark:text-gray-06 md:row-start-auto md:text-center"
+                    tag={'span'}
+                  >
+                    <span className="md:hidden">{`${item.quantity} x ${currency} ${formatInvoiceAmount(item.price, localeAmountDue)}`}</span>
+                    <span className="hidden md:inline">{item.quantity}</span>
+                  </Text>
+                  <Text
+                    className="hidden text-gray-07 font-bold text-right dark:text-gray-06 md:block"
+                    tag={'span'}
+                  >
+                    {`${currency} ${formatInvoiceAmount(item.price, localeAmountDue)}`}
+                  </Text>
+                  <Text
+                    className="font-bold text-gray-08 text-right row-start-1 col-start-2 dark:text-white md:row-start-auto md:col-start-auto"
+                    tag={'span'}
+                  >
+                    {`${currency} ${formatInvoiceAmount(getLineItemTotal(item.quantity, item.price), localeAmountDue)}`}
+                  </Text>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Amount due footer */}
+          <div className="flex items-center justify-between bg-gray-09 px-6 py-6 md:px-8 dark:bg-gray-12">
+            <Text className="text-white" tag={'span'}>
+              {labels.amountDue}
+            </Text>
+            <Text className="font-bold text-white text-2xl" tag={'span'}>
+              {`${currency} ${formatInvoiceAmount(invoiceAmountDue, localeAmountDue)}`}
+            </Text>
+          </div>
+        </div>
+      </div>
+
+      {/* Actions bar (mobile: pinned below the card) */}
+      <div className="md:hidden rounded-lg bg-white px-6 py-5 drop-shadow-lg dark:bg-blue-03">
+        {actions}
+      </div>
+    </div>
+  );
+};
+
+export default InvoiceDetails;

--- a/frontend/src/features/invoices/components/invoice-details/invoice-details.types.ts
+++ b/frontend/src/features/invoices/components/invoice-details/invoice-details.types.ts
@@ -1,0 +1,53 @@
+import { InvoiceLocale, InvoiceStatus } from '@/features/invoices/types/invoice';
+
+export interface InvoiceAddress {
+  street: string;
+  city: string;
+  postCode: string;
+  country: string;
+}
+
+export interface InvoiceLineItem {
+  name: string;
+  quantity: number;
+  price: number;
+}
+
+/** All user-facing copy, passed in so the component stays presentation-only. */
+export interface InvoiceDetailsLabels {
+  goBack: string;
+  status: string;
+  statusText: string;
+  edit: string;
+  delete: string;
+  markAsPaid: string;
+  billTo: string;
+  sentTo: string;
+  invoiceDate: string;
+  paymentDue: string;
+  itemName: string;
+  quantity: string;
+  price: string;
+  total: string;
+  amountDue: string;
+}
+
+export interface IInvoiceDetailsProps {
+  invoiceId: string;
+  description: string;
+  invoiceStatus: InvoiceStatus;
+  invoiceDate: string;
+  paymentDue: string;
+  senderAddress: InvoiceAddress;
+  clientName: string;
+  clientEmail: string;
+  clientAddress: InvoiceAddress;
+  items: InvoiceLineItem[];
+  invoiceAmountDue: number;
+  localeAmountDue?: InvoiceLocale;
+  labels: InvoiceDetailsLabels;
+  onGoBack?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onMarkAsPaid?: () => void;
+}

--- a/frontend/src/features/invoices/utils/get-line-item-total.test.ts
+++ b/frontend/src/features/invoices/utils/get-line-item-total.test.ts
@@ -1,0 +1,19 @@
+import { getLineItemTotal } from '@/features/invoices/utils/get-line-item-total';
+
+describe('getLineItemTotal', () => {
+  it('multiplies quantity by unit price', () => {
+    expect(getLineItemTotal(2, 200)).toBe(400);
+  });
+
+  it('returns the unit price for a quantity of one', () => {
+    expect(getLineItemTotal(1, 156)).toBe(156);
+  });
+
+  it('returns zero when the quantity is zero', () => {
+    expect(getLineItemTotal(0, 156)).toBe(0);
+  });
+
+  it('preserves fractional amounts', () => {
+    expect(getLineItemTotal(3, 12.5)).toBe(37.5);
+  });
+});

--- a/frontend/src/features/invoices/utils/get-line-item-total.ts
+++ b/frontend/src/features/invoices/utils/get-line-item-total.ts
@@ -1,0 +1,2 @@
+/** Returns the total for an invoice line item (quantity × unit price). */
+export const getLineItemTotal = (quantity: number, price: number): number => quantity * price;

--- a/frontend/src/styles/ui/button.css
+++ b/frontend/src/styles/ui/button.css
@@ -3,23 +3,24 @@
     @apply rounded-full py-[18px] px-[24px] text-[18px] font-bold leading-normal flex items-center w-fit;
   }
   .btn {
+    @apply cursor-pointer;
     .icon {
       @apply max-w-full;
     }
     span {
       @apply w-full leading-none;
     }
-    &--primary {
-      @apply text-white bg-blue-01 hover:bg-blue-02;
-    }
-    &--secondary {
-      @apply text-gray-07 bg-gray-05b hover:bg-gray-05;
-    }
-    &--dark {
-      @apply text-gray-06 bg-gray-09 hover:bg-gray-08;
-    }
-    &--danger {
-      @apply text-white bg-red-08 hover:bg-red-10;
-    }
+  }
+  .btn--primary {
+    @apply text-white bg-blue-01 hover:bg-blue-02;
+  }
+  .btn--secondary {
+    @apply text-gray-07 bg-gray-05b hover:bg-gray-05;
+  }
+  .btn--dark {
+    @apply text-gray-06 bg-gray-09 hover:bg-gray-08;
+  }
+  .btn--danger {
+    @apply text-white bg-red-08 hover:bg-red-10;
   }
 }


### PR DESCRIPTION
Adds the invoice details (view invoice) screen as a presentation-only feature component, plus a Storybook story with Pending, Paid, and Draft states.

## Changes
- New `InvoiceDetails` component under `features/invoices/components/invoice-details/` (component, types, story), built from the Figma design and following the bulletproof-react layering (copy, data, and handlers all arrive via props).
- New tested `getLineItemTotal` util so line-item math stays out of the presentation layer.
- Fixes a pre-existing bug in `button.css`: variant styles used SCSS-style `&--modifier` nesting, which does not concatenate in Tailwind v4 native CSS nesting, so all non-custom buttons rendered unstyled. Flattened to `.btn--primary/secondary/dark/danger` selectors. This restores styling for every button across the app.
- Adds a pointer cursor to all buttons at the component level.

Reuses the existing `Button`, `Text`, and `Icon` primitives and the existing amount/status utils.