### PR TITLE
refactor: add layout primitives and adopt them for container divs

### DIFF
--- a/frontend/src/app/[locale]/home-view.tsx
+++ b/frontend/src/app/[locale]/home-view.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import MainMenu from '@/components/layouts/main-menu/main-menu';
+import Container from '@/components/ui/container/container';
+import Flex from '@/components/ui/flex/flex';
 import InvoiceBar from '@/features/invoices/components/invoice-bar/invoice-bar';
 import type { FilterState } from '@/features/invoices/components/invoice-bar/invoice-bar.types';
 import Invoice from '@/features/invoices/components/invoice/invoice';
@@ -71,14 +73,19 @@ const HomeView = () => {
   );
 
   return (
-    <div className="min-h-screen lg:pl-25">
+    <Container className="min-h-screen lg:pl-25">
       <MainMenu
         darkmode={theme}
         darkmodeBtn={{ darkAria: tMenu('switchToDark'), lightAria: tMenu('switchToLight') }}
         darkmodeToggle={toggleTheme}
         profile={{ profileImageAlt: tMenu('profileImageAlt') }}
       />
-      <main className="mx-auto flex max-w-250 flex-col gap-y-8 px-6 py-8 md:py-12 lg:py-16">
+      <Flex
+        as="main"
+        className="mx-auto max-w-250 px-6 py-8 md:py-12 lg:py-16"
+        direction="col"
+        gapY={8}
+      >
         <InvoiceBar
           filters={filters}
           filterStatusBtn={{ mobile: t('filterMobile'), desktop: t('filterDesktop') }}
@@ -96,7 +103,7 @@ const HomeView = () => {
             desktop: t('totalDesktop', { count: SAMPLE_INVOICES.length }),
           }}
         />
-        <ul className="flex flex-col gap-y-4">
+        <Flex as="ul" direction="col" gapY={4}>
           {visibleInvoices.map((invoice) => (
             <li key={invoice.invoiceId}>
               <Invoice
@@ -106,9 +113,9 @@ const HomeView = () => {
               />
             </li>
           ))}
-        </ul>
-      </main>
-    </div>
+        </Flex>
+      </Flex>
+    </Container>
   );
 };
 

--- a/frontend/src/components/layouts/main-menu/__snapshots__/main-menu.snapshot.test.tsx.snap
+++ b/frontend/src/components/layouts/main-menu/__snapshots__/main-menu.snapshot.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Main Menu Component renders correctly with default props 1`] = `
 <div>
   <nav
-    class="bg-gray-09 flex justify-between items-stretch lg:flex-col lg:w-fit lg:rounded-r-[20px] lg:rounded-tr-3xl lg:h-screen lg:fixed lg:left-0"
+    class="flex flex-row items-stretch justify-between bg-gray-09 lg:flex-col lg:w-fit lg:rounded-r-[20px] lg:rounded-tr-3xl lg:h-screen lg:fixed lg:left-0"
   >
     <a
       class="btn btn--custom w-[50px] h-[50px] xs:w-[72px] xs:h-[72px] md:w-[80px] md:h-[80px]"
@@ -14,7 +14,7 @@ exports[`Main Menu Component renders correctly with default props 1`] = `
       />
     </a>
     <div
-      class="flex gap-5 px-6 md:gap-8 md:px-8 lg:flex-col lg:gap-5 lg:px-0 lg:py-6"
+      class="flex flex-row gap-5 px-6 md:gap-8 md:px-8 lg:flex-col lg:gap-5 lg:px-0 lg:py-6"
     >
       <button
         class="btn btn--custom h-fit self-center"

--- a/frontend/src/components/layouts/main-menu/main-menu.tsx
+++ b/frontend/src/components/layouts/main-menu/main-menu.tsx
@@ -1,14 +1,18 @@
 import React, { JSX } from 'react';
 import { IMainMenuProps } from '@/components/layouts/main-menu/main-menu.types';
 import Button from '@/components/ui/button/button';
+import Flex from '@/components/ui/flex/flex';
 import Image from 'next/image';
 import { DARK_MODE } from '@/config/constants';
 import Link from 'next/link';
 const MainMenu = (props: IMainMenuProps): JSX.Element => {
   const { darkmode, darkmodeToggle, profile, darkmodeBtn, ...rest } = props;
   return (
-    <nav
-      className="bg-gray-09 flex justify-between items-stretch lg:flex-col lg:w-fit lg:rounded-r-[20px] lg:rounded-tr-3xl lg:h-screen lg:fixed lg:left-0"
+    <Flex
+      align="stretch"
+      as="nav"
+      className="bg-gray-09 lg:flex-col lg:w-fit lg:rounded-r-[20px] lg:rounded-tr-3xl lg:h-screen lg:fixed lg:left-0"
+      justify="between"
       {...rest}
     >
       <Button
@@ -18,7 +22,7 @@ const MainMenu = (props: IMainMenuProps): JSX.Element => {
         iconLeftClassName="w-full h-full"
         variant="custom"
       />
-      <div className="flex gap-5 px-6 md:gap-8 md:px-8 lg:flex-col lg:gap-5 lg:px-0 lg:py-6">
+      <Flex className="px-6 md:gap-8 md:px-8 lg:flex-col lg:gap-5 lg:px-0 lg:py-6" gap={5}>
         <Button
           aria-label={darkmode === DARK_MODE ? darkmodeBtn?.lightAria : darkmodeBtn?.darkAria}
           className="h-fit self-center"
@@ -41,8 +45,8 @@ const MainMenu = (props: IMainMenuProps): JSX.Element => {
             width={64}
           />
         </Link>
-      </div>
-    </nav>
+      </Flex>
+    </Flex>
   );
 };
 

--- a/frontend/src/components/ui/checkbox/__snapshots__/checkbox.snapshot.test.tsx.snap
+++ b/frontend/src/components/ui/checkbox/__snapshots__/checkbox.snapshot.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Checkbox Component renders correctly with a label 1`] = `
 <div>
   <div
-    class="flex items-center gap-x-[13px]"
+    class="flex flex-row items-center gap-x-[13px]"
   >
     <input
       class="relative peer shrink-0 appearance-none w-5 h-5 bg-gray-05 dark:bg-blue-03 border-2 border-blue-01 rounded-sm checked:bg-blue-01 dark:checked:bg-blue-01 checked:border-0 cursor-pointer"
@@ -37,7 +37,7 @@ exports[`Checkbox Component renders correctly with a label 1`] = `
 exports[`Checkbox Component renders correctly without a label 1`] = `
 <div>
   <div
-    class="flex items-center gap-x-[13px]"
+    class="flex flex-row items-center gap-x-[13px]"
   >
     <input
       class="relative peer shrink-0 appearance-none w-5 h-5 bg-gray-05 dark:bg-blue-03 border-2 border-blue-01 rounded-sm checked:bg-blue-01 dark:checked:bg-blue-01 checked:border-0 cursor-pointer"
@@ -69,7 +69,7 @@ exports[`Checkbox Component renders correctly without a label 1`] = `
 exports[`Checkbox Component renders with custom class names 1`] = `
 <div>
   <div
-    class="flex items-center gap-x-[13px]"
+    class="flex flex-row items-center gap-x-[13px]"
   >
     <input
       class="relative peer shrink-0 appearance-none w-5 h-5 bg-gray-05 dark:bg-blue-03 border-2 border-blue-01 rounded-sm checked:bg-blue-01 dark:checked:bg-blue-01 checked:border-0 cursor-pointer"

--- a/frontend/src/components/ui/checkbox/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox/checkbox.tsx
@@ -11,13 +11,14 @@
  */
 
 import { ICheckboxProps } from '@/components/ui/checkbox/checkbox.types';
+import Flex from '@/components/ui/flex/flex';
 import Text from '@/components/ui/text/text';
 import { JSX } from 'react';
 
 const Checkbox = (props: ICheckboxProps): JSX.Element => {
   const { labelId, label, ...rest } = props;
   return (
-    <div className="flex items-center gap-x-[13px]">
+    <Flex align="center" className="gap-x-[13px]">
       <input
         className="relative peer shrink-0 appearance-none w-5 h-5 bg-gray-05 dark:bg-blue-03 border-2 border-blue-01 rounded-sm checked:bg-blue-01 dark:checked:bg-blue-01 checked:border-0 cursor-pointer"
         id={labelId}
@@ -44,7 +45,7 @@ const Checkbox = (props: ICheckboxProps): JSX.Element => {
       >
         <path d="M1.5 4.49976L3.62425 6.62402L8.96995 1.27832" stroke="white" strokeWidth="2" />
       </svg>
-    </div>
+    </Flex>
   );
 };
 

--- a/frontend/src/components/ui/container/__snapshots__/container.snapshot.test.tsx.snap
+++ b/frontend/src/components/ui/container/__snapshots__/container.snapshot.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Container Component renders correctly 1`] = `
+<div>
+  <section
+    class="p-4"
+  >
+    content
+  </section>
+</div>
+`;

--- a/frontend/src/components/ui/container/container.snapshot.test.tsx
+++ b/frontend/src/components/ui/container/container.snapshot.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Container from '@/components/ui/container/container';
+
+describe('Container Component', () => {
+  it('renders correctly', () => {
+    const { container } = render(
+      <Container as="section" className="p-4">
+        content
+      </Container>
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/ui/container/container.stories.tsx
+++ b/frontend/src/components/ui/container/container.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import Container from '@/components/ui/container/container';
+
+const meta = {
+  title: 'Utils/Container',
+  component: Container,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Generic block-level layout wrapper. Renders a `div` by default and accepts an `as` prop to render any semantic element. All styling is supplied through `className`.',
+      },
+    },
+  },
+  argTypes: {
+    as: {
+      control: 'text',
+      description: 'Element or component to render.',
+      table: { type: { summary: 'ElementType' }, defaultValue: { summary: 'div' } },
+    },
+    className: {
+      control: 'text',
+      description: 'Additional Tailwind/utility classes applied to the element.',
+      table: { type: { summary: 'string' } },
+    },
+    children: {
+      control: false,
+      description: 'Content rendered inside the container.',
+      table: { type: { summary: 'ReactNode' } },
+    },
+  },
+} satisfies Meta<typeof Container>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    className: 'p-6 bg-gray-05b rounded-lg',
+    children: 'Container content',
+  },
+};
+
+export const AsSection: Story = {
+  args: {
+    as: 'section',
+    className: 'p-6 bg-gray-05b rounded-lg',
+    children: 'Rendered as a <section> element',
+  },
+};

--- a/frontend/src/components/ui/container/container.test.tsx
+++ b/frontend/src/components/ui/container/container.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Container from '@/components/ui/container/container';
+
+describe('Container Component - Unit Tests', () => {
+  const testId = 'container-test-id';
+
+  it('renders a div by default with its children', () => {
+    render(<Container data-testid={testId}>content</Container>);
+    const element = screen.getByTestId(testId);
+    expect(element.tagName).toBe('DIV');
+    expect(element).toHaveTextContent('content');
+  });
+
+  it('renders the element passed via `as`', () => {
+    render(
+      <Container as="section" data-testid={testId}>
+        content
+      </Container>
+    );
+    expect(screen.getByTestId(testId).tagName).toBe('SECTION');
+  });
+
+  it('applies the provided `className`', () => {
+    render(<Container className="test-class" data-testid={testId} />);
+    expect(screen.getByTestId(testId)).toHaveClass('test-class');
+  });
+
+  it('forwards arbitrary props', () => {
+    render(<Container aria-label="label" data-testid={testId} />);
+    expect(screen.getByTestId(testId)).toHaveAttribute('aria-label', 'label');
+  });
+});

--- a/frontend/src/components/ui/container/container.tsx
+++ b/frontend/src/components/ui/container/container.tsx
@@ -1,0 +1,28 @@
+/**
+ * @name Container
+ * @author Tyrell Curry <tyrellcurryio@gmail.com>
+ *
+ * Generic block-level layout wrapper. Renders a `div` by default and accepts an
+ * `as` prop to render any semantic element (section, article, etc.). All layout
+ * styling is supplied through `className`.
+ *
+ * @param as - element/component to render (default: 'div')
+ * @param className
+ * @param children
+ *
+ * @returns {JSX.Element}
+ */
+import { JSX } from 'react';
+import { IContainerProps } from '@/components/ui/container/container.types';
+
+const Container = (props: IContainerProps): JSX.Element => {
+  const { as: Component = 'div', className, children, ...rest } = props;
+
+  return (
+    <Component className={className} {...rest}>
+      {children}
+    </Component>
+  );
+};
+
+export default Container;

--- a/frontend/src/components/ui/container/container.types.ts
+++ b/frontend/src/components/ui/container/container.types.ts
@@ -1,0 +1,8 @@
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
+
+export interface IContainerProps extends ComponentPropsWithoutRef<'div'> {
+  /** Element/component to render. Defaults to `div`. */
+  as?: ElementType;
+  className?: string;
+  children?: ReactNode;
+}

--- a/frontend/src/components/ui/flex/__snapshots__/flex.snapshot.test.tsx.snap
+++ b/frontend/src/components/ui/flex/__snapshots__/flex.snapshot.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Flex Component renders correctly 1`] = `
+<div>
+  <div
+    class="flex flex-col items-center justify-between gap-4"
+  >
+    content
+  </div>
+</div>
+`;

--- a/frontend/src/components/ui/flex/flex.snapshot.test.tsx
+++ b/frontend/src/components/ui/flex/flex.snapshot.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Flex from '@/components/ui/flex/flex';
+
+describe('Flex Component', () => {
+  it('renders correctly', () => {
+    const { container } = render(
+      <Flex align="center" direction="col" gap={4} justify="between">
+        content
+      </Flex>
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/ui/flex/flex.stories.tsx
+++ b/frontend/src/components/ui/flex/flex.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import Flex from '@/components/ui/flex/flex';
+
+const Box = ({ children }: { children: React.ReactNode }) => (
+  <div className="bg-blue-01 text-white rounded-md px-4 py-3 text-center">{children}</div>
+);
+
+const items = [<Box key="1">1</Box>, <Box key="2">2</Box>, <Box key="3">3</Box>];
+
+const spacingOptions = [0, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10, 11, 12];
+
+const meta = {
+  title: 'Utils/Flex',
+  component: Flex,
+  tags: ['autodocs'],
+  args: { children: items },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Flexbox layout primitive. Exposes the common flex controls as props and renders a `div` by default (or any element via `as`). Responsive/breakpoint variants are passed through `className`.',
+      },
+    },
+  },
+  argTypes: {
+    as: {
+      control: 'text',
+      description: 'Element or component to render.',
+      table: { type: { summary: 'ElementType' }, defaultValue: { summary: 'div' } },
+    },
+    inline: {
+      control: 'boolean',
+      description: 'Render `inline-flex` instead of `flex`.',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
+    },
+    direction: {
+      control: 'select',
+      options: ['row', 'col', 'row-reverse', 'col-reverse'],
+      description: 'Main axis direction (`flex-direction`).',
+      table: { type: { summary: 'FlexDirection' }, defaultValue: { summary: 'row' } },
+    },
+    align: {
+      control: 'select',
+      options: ['start', 'center', 'end', 'stretch', 'baseline'],
+      description: 'Cross-axis alignment (`align-items`).',
+      table: { type: { summary: 'FlexAlign' } },
+    },
+    justify: {
+      control: 'select',
+      options: ['start', 'center', 'end', 'between', 'around', 'evenly'],
+      description: 'Main-axis distribution (`justify-content`).',
+      table: { type: { summary: 'FlexJustify' } },
+    },
+    wrap: {
+      control: 'select',
+      options: ['wrap', 'nowrap', 'wrap-reverse'],
+      description: 'Wrapping behaviour (`flex-wrap`).',
+      table: { type: { summary: 'FlexWrap' } },
+    },
+    gap: {
+      control: 'select',
+      options: spacingOptions,
+      description: 'Gap on both axes (Tailwind spacing scale).',
+      table: { type: { summary: 'Spacing' } },
+    },
+    gapX: {
+      control: 'select',
+      options: spacingOptions,
+      description: 'Horizontal (column) gap.',
+      table: { type: { summary: 'Spacing' } },
+    },
+    gapY: {
+      control: 'select',
+      options: spacingOptions,
+      description: 'Vertical (row) gap.',
+      table: { type: { summary: 'Spacing' } },
+    },
+    className: {
+      control: 'text',
+      description: 'Additional classes, including responsive/breakpoint variants.',
+      table: { type: { summary: 'string' } },
+    },
+    children: {
+      control: false,
+      description: 'Content rendered inside the flex container.',
+      table: { type: { summary: 'ReactNode' } },
+    },
+  },
+} satisfies Meta<typeof Flex>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Row: Story = {
+  args: { gap: 4 },
+};
+
+export const Column: Story = {
+  args: { direction: 'col', gap: 4 },
+};
+
+export const SpaceBetween: Story = {
+  args: { justify: 'between', className: 'w-full' },
+};
+
+export const Centered: Story = {
+  args: { align: 'center', justify: 'center', gap: 4, className: 'h-40 bg-gray-05b rounded-lg' },
+};
+
+export const Wrap: Story = {
+  args: {
+    gap: 2,
+    wrap: 'wrap',
+    className: 'w-40',
+    children: Array.from({ length: 8 }, (_, i) => <Box key={i}>{i + 1}</Box>),
+  },
+};

--- a/frontend/src/components/ui/flex/flex.test.tsx
+++ b/frontend/src/components/ui/flex/flex.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Flex from '@/components/ui/flex/flex';
+
+describe('Flex Component - Unit Tests', () => {
+  const testId = 'flex-test-id';
+
+  it('renders a flex div by default with its children', () => {
+    render(<Flex data-testid={testId}>content</Flex>);
+    const element = screen.getByTestId(testId);
+    expect(element.tagName).toBe('DIV');
+    expect(element).toHaveClass('flex', 'flex-row');
+    expect(element).toHaveTextContent('content');
+  });
+
+  it('maps direction, align, justify and wrap props to classes', () => {
+    render(
+      <Flex align="center" data-testid={testId} direction="col" justify="between" wrap="wrap" />
+    );
+    expect(screen.getByTestId(testId)).toHaveClass(
+      'flex',
+      'flex-col',
+      'items-center',
+      'justify-between',
+      'flex-wrap'
+    );
+  });
+
+  it('maps gap, gapX and gapY props to classes', () => {
+    render(<Flex data-testid={testId} gap={4} gapX={2} gapY={1.5} />);
+    expect(screen.getByTestId(testId)).toHaveClass('gap-4', 'gap-x-2', 'gap-y-1.5');
+  });
+
+  it('renders `inline-flex` when `inline` is set', () => {
+    render(<Flex data-testid={testId} inline />);
+    const element = screen.getByTestId(testId);
+    expect(element).toHaveClass('inline-flex');
+    expect(element).not.toHaveClass('flex');
+  });
+
+  it('renders the element passed via `as` and merges `className`', () => {
+    render(<Flex as="ul" className="custom" data-testid={testId} />);
+    const element = screen.getByTestId(testId);
+    expect(element.tagName).toBe('UL');
+    expect(element).toHaveClass('flex', 'custom');
+  });
+});

--- a/frontend/src/components/ui/flex/flex.tsx
+++ b/frontend/src/components/ui/flex/flex.tsx
@@ -1,0 +1,151 @@
+/**
+ * @name Flex
+ * @author Tyrell Curry <tyrellcurryio@gmail.com>
+ *
+ * Flexbox layout primitive. Exposes the common flex controls as props
+ * (direction, align, justify, wrap, gap) and renders a `div` by default, or any
+ * element via `as`. Responsive/breakpoint variants are passed through
+ * `className`.
+ *
+ * @param as - element/component to render (default: 'div')
+ * @param inline - render `inline-flex` instead of `flex`
+ * @param direction - default: 'row'
+ * @param align
+ * @param justify
+ * @param wrap
+ * @param gap - gap on both axes
+ * @param gapX - horizontal gap
+ * @param gapY - vertical gap
+ * @param className
+ * @param children
+ *
+ * @returns {JSX.Element}
+ */
+import { JSX } from 'react';
+import classNames from 'classnames';
+import {
+  FlexAlign,
+  FlexDirection,
+  FlexJustify,
+  FlexWrap,
+  IFlexProps,
+  Spacing,
+} from '@/components/ui/flex/flex.types';
+
+const directionClasses: Record<FlexDirection, string> = {
+  row: 'flex-row',
+  col: 'flex-col',
+  'row-reverse': 'flex-row-reverse',
+  'col-reverse': 'flex-col-reverse',
+};
+
+const alignClasses: Record<FlexAlign, string> = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  stretch: 'items-stretch',
+  baseline: 'items-baseline',
+};
+
+const justifyClasses: Record<FlexJustify, string> = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between',
+  around: 'justify-around',
+  evenly: 'justify-evenly',
+};
+
+const wrapClasses: Record<FlexWrap, string> = {
+  wrap: 'flex-wrap',
+  nowrap: 'flex-nowrap',
+  'wrap-reverse': 'flex-wrap-reverse',
+};
+
+const gapClasses: Record<Spacing, string> = {
+  0: 'gap-0',
+  0.5: 'gap-0.5',
+  1: 'gap-1',
+  1.5: 'gap-1.5',
+  2: 'gap-2',
+  2.5: 'gap-2.5',
+  3: 'gap-3',
+  4: 'gap-4',
+  5: 'gap-5',
+  6: 'gap-6',
+  8: 'gap-8',
+  10: 'gap-10',
+  11: 'gap-11',
+  12: 'gap-12',
+};
+
+const gapXClasses: Record<Spacing, string> = {
+  0: 'gap-x-0',
+  0.5: 'gap-x-0.5',
+  1: 'gap-x-1',
+  1.5: 'gap-x-1.5',
+  2: 'gap-x-2',
+  2.5: 'gap-x-2.5',
+  3: 'gap-x-3',
+  4: 'gap-x-4',
+  5: 'gap-x-5',
+  6: 'gap-x-6',
+  8: 'gap-x-8',
+  10: 'gap-x-10',
+  11: 'gap-x-11',
+  12: 'gap-x-12',
+};
+
+const gapYClasses: Record<Spacing, string> = {
+  0: 'gap-y-0',
+  0.5: 'gap-y-0.5',
+  1: 'gap-y-1',
+  1.5: 'gap-y-1.5',
+  2: 'gap-y-2',
+  2.5: 'gap-y-2.5',
+  3: 'gap-y-3',
+  4: 'gap-y-4',
+  5: 'gap-y-5',
+  6: 'gap-y-6',
+  8: 'gap-y-8',
+  10: 'gap-y-10',
+  11: 'gap-y-11',
+  12: 'gap-y-12',
+};
+
+const Flex = (props: IFlexProps): JSX.Element => {
+  const {
+    as: Component = 'div',
+    inline = false,
+    direction = 'row',
+    align,
+    justify,
+    wrap,
+    gap,
+    gapX,
+    gapY,
+    className,
+    children,
+    ...rest
+  } = props;
+
+  const classes = classNames(
+    inline ? 'inline-flex' : 'flex',
+    directionClasses[direction],
+    align && alignClasses[align],
+    justify && justifyClasses[justify],
+    wrap && wrapClasses[wrap],
+    gap !== undefined && gapClasses[gap],
+    gapX !== undefined && gapXClasses[gapX],
+    gapY !== undefined && gapYClasses[gapY],
+    className
+  );
+
+  return (
+    <Component className={classes} {...rest}>
+      {children}
+    </Component>
+  );
+};
+
+export default Flex;

--- a/frontend/src/components/ui/flex/flex.types.ts
+++ b/frontend/src/components/ui/flex/flex.types.ts
@@ -1,0 +1,28 @@
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
+
+export type FlexDirection = 'row' | 'col' | 'row-reverse' | 'col-reverse';
+export type FlexAlign = 'start' | 'center' | 'end' | 'stretch' | 'baseline';
+export type FlexJustify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';
+export type FlexWrap = 'wrap' | 'nowrap' | 'wrap-reverse';
+
+/** Supported spacing steps for gap props (maps to Tailwind's spacing scale). */
+export type Spacing = 0 | 0.5 | 1 | 1.5 | 2 | 2.5 | 3 | 4 | 5 | 6 | 8 | 10 | 11 | 12;
+
+export interface IFlexProps extends ComponentPropsWithoutRef<'div'> {
+  /** Element/component to render. Defaults to `div`. */
+  as?: ElementType;
+  /** Renders `inline-flex` instead of `flex`. */
+  inline?: boolean;
+  direction?: FlexDirection;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+  wrap?: FlexWrap;
+  /** Gap on both axes. */
+  gap?: Spacing;
+  /** Horizontal (column) gap. */
+  gapX?: Spacing;
+  /** Vertical (row) gap. */
+  gapY?: Spacing;
+  className?: string;
+  children?: ReactNode;
+}

--- a/frontend/src/components/ui/grid/__snapshots__/grid.snapshot.test.tsx.snap
+++ b/frontend/src/components/ui/grid/__snapshots__/grid.snapshot.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Grid Component renders correctly 1`] = `
+<div>
+  <div
+    class="grid grid-cols-3 items-center gap-4"
+  >
+    content
+  </div>
+</div>
+`;

--- a/frontend/src/components/ui/grid/grid.snapshot.test.tsx
+++ b/frontend/src/components/ui/grid/grid.snapshot.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Grid from '@/components/ui/grid/grid';
+
+describe('Grid Component', () => {
+  it('renders correctly', () => {
+    const { container } = render(
+      <Grid align="center" cols={3} gap={4}>
+        content
+      </Grid>
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/ui/grid/grid.stories.tsx
+++ b/frontend/src/components/ui/grid/grid.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import Grid from '@/components/ui/grid/grid';
+
+const Box = ({ children }: { children: React.ReactNode }) => (
+  <div className="bg-blue-01 text-white rounded-md px-4 py-3 text-center">{children}</div>
+);
+
+const items = Array.from({ length: 6 }, (_, i) => <Box key={i}>{i + 1}</Box>);
+
+const spacingOptions = [0, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10, 11, 12];
+
+const meta = {
+  title: 'Utils/Grid',
+  component: Grid,
+  tags: ['autodocs'],
+  args: { children: items },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'CSS grid layout primitive. Exposes column count, gap and alignment as props and renders a `div` by default (or any element via `as`). Arbitrary column templates and responsive variants are passed through `className`.',
+      },
+    },
+  },
+  argTypes: {
+    as: {
+      control: 'text',
+      description: 'Element or component to render.',
+      table: { type: { summary: 'ElementType' }, defaultValue: { summary: 'div' } },
+    },
+    cols: {
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6, 12],
+      description: 'Number of equal-width columns. Use `className` for arbitrary templates.',
+      table: { type: { summary: 'GridCols' } },
+    },
+    align: {
+      control: 'select',
+      options: ['start', 'center', 'end', 'stretch', 'baseline'],
+      description: 'Block-axis alignment of items (`align-items`).',
+      table: { type: { summary: 'FlexAlign' } },
+    },
+    gap: {
+      control: 'select',
+      options: spacingOptions,
+      description: 'Gap on both axes (Tailwind spacing scale).',
+      table: { type: { summary: 'Spacing' } },
+    },
+    gapX: {
+      control: 'select',
+      options: spacingOptions,
+      description: 'Horizontal (column) gap.',
+      table: { type: { summary: 'Spacing' } },
+    },
+    gapY: {
+      control: 'select',
+      options: spacingOptions,
+      description: 'Vertical (row) gap.',
+      table: { type: { summary: 'Spacing' } },
+    },
+    className: {
+      control: 'text',
+      description: 'Additional classes, including arbitrary templates and responsive variants.',
+      table: { type: { summary: 'string' } },
+    },
+    children: {
+      control: false,
+      description: 'Content rendered inside the grid container.',
+      table: { type: { summary: 'ReactNode' } },
+    },
+  },
+} satisfies Meta<typeof Grid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TwoColumns: Story = {
+  args: { cols: 2, gap: 4 },
+};
+
+export const ThreeColumns: Story = {
+  args: { cols: 3, gap: 4 },
+};
+
+export const SeparateAxisGaps: Story = {
+  args: { cols: 3, gapX: 2, gapY: 8 },
+};

--- a/frontend/src/components/ui/grid/grid.test.tsx
+++ b/frontend/src/components/ui/grid/grid.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Grid from '@/components/ui/grid/grid';
+
+describe('Grid Component - Unit Tests', () => {
+  const testId = 'grid-test-id';
+
+  it('renders a grid div by default with its children', () => {
+    render(<Grid data-testid={testId}>content</Grid>);
+    const element = screen.getByTestId(testId);
+    expect(element.tagName).toBe('DIV');
+    expect(element).toHaveClass('grid');
+    expect(element).toHaveTextContent('content');
+  });
+
+  it('maps cols, align and gap props to classes', () => {
+    render(<Grid align="center" cols={3} data-testid={testId} gap={4} />);
+    expect(screen.getByTestId(testId)).toHaveClass('grid', 'grid-cols-3', 'items-center', 'gap-4');
+  });
+
+  it('maps gapX and gapY props to classes', () => {
+    render(<Grid data-testid={testId} gapX={2} gapY={8} />);
+    expect(screen.getByTestId(testId)).toHaveClass('gap-x-2', 'gap-y-8');
+  });
+
+  it('renders the element passed via `as` and merges `className`', () => {
+    render(<Grid as="ul" className="custom" data-testid={testId} />);
+    const element = screen.getByTestId(testId);
+    expect(element.tagName).toBe('UL');
+    expect(element).toHaveClass('grid', 'custom');
+  });
+});

--- a/frontend/src/components/ui/grid/grid.tsx
+++ b/frontend/src/components/ui/grid/grid.tsx
@@ -1,0 +1,124 @@
+/**
+ * @name Grid
+ * @author Tyrell Curry <tyrellcurryio@gmail.com>
+ *
+ * CSS grid layout primitive. Exposes column count, gap and alignment as props
+ * and renders a `div` by default, or any element via `as`. Arbitrary column
+ * templates and responsive variants are passed through `className`.
+ *
+ * @param as - element/component to render (default: 'div')
+ * @param cols - number of equal-width columns
+ * @param align
+ * @param gap - gap on both axes
+ * @param gapX - horizontal gap
+ * @param gapY - vertical gap
+ * @param className
+ * @param children
+ *
+ * @returns {JSX.Element}
+ */
+import { JSX } from 'react';
+import classNames from 'classnames';
+import { FlexAlign, Spacing } from '@/components/ui/flex/flex.types';
+import { GridCols, IGridProps } from '@/components/ui/grid/grid.types';
+
+const colsClasses: Record<GridCols, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4',
+  5: 'grid-cols-5',
+  6: 'grid-cols-6',
+  12: 'grid-cols-12',
+};
+
+const alignClasses: Record<FlexAlign, string> = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  stretch: 'items-stretch',
+  baseline: 'items-baseline',
+};
+
+const gapClasses: Record<Spacing, string> = {
+  0: 'gap-0',
+  0.5: 'gap-0.5',
+  1: 'gap-1',
+  1.5: 'gap-1.5',
+  2: 'gap-2',
+  2.5: 'gap-2.5',
+  3: 'gap-3',
+  4: 'gap-4',
+  5: 'gap-5',
+  6: 'gap-6',
+  8: 'gap-8',
+  10: 'gap-10',
+  11: 'gap-11',
+  12: 'gap-12',
+};
+
+const gapXClasses: Record<Spacing, string> = {
+  0: 'gap-x-0',
+  0.5: 'gap-x-0.5',
+  1: 'gap-x-1',
+  1.5: 'gap-x-1.5',
+  2: 'gap-x-2',
+  2.5: 'gap-x-2.5',
+  3: 'gap-x-3',
+  4: 'gap-x-4',
+  5: 'gap-x-5',
+  6: 'gap-x-6',
+  8: 'gap-x-8',
+  10: 'gap-x-10',
+  11: 'gap-x-11',
+  12: 'gap-x-12',
+};
+
+const gapYClasses: Record<Spacing, string> = {
+  0: 'gap-y-0',
+  0.5: 'gap-y-0.5',
+  1: 'gap-y-1',
+  1.5: 'gap-y-1.5',
+  2: 'gap-y-2',
+  2.5: 'gap-y-2.5',
+  3: 'gap-y-3',
+  4: 'gap-y-4',
+  5: 'gap-y-5',
+  6: 'gap-y-6',
+  8: 'gap-y-8',
+  10: 'gap-y-10',
+  11: 'gap-y-11',
+  12: 'gap-y-12',
+};
+
+const Grid = (props: IGridProps): JSX.Element => {
+  const {
+    as: Component = 'div',
+    cols,
+    align,
+    gap,
+    gapX,
+    gapY,
+    className,
+    children,
+    ...rest
+  } = props;
+
+  const classes = classNames(
+    'grid',
+    cols && colsClasses[cols],
+    align && alignClasses[align],
+    gap !== undefined && gapClasses[gap],
+    gapX !== undefined && gapXClasses[gapX],
+    gapY !== undefined && gapYClasses[gapY],
+    className
+  );
+
+  return (
+    <Component className={classes} {...rest}>
+      {children}
+    </Component>
+  );
+};
+
+export default Grid;

--- a/frontend/src/components/ui/grid/grid.types.ts
+++ b/frontend/src/components/ui/grid/grid.types.ts
@@ -1,0 +1,20 @@
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
+import { FlexAlign, Spacing } from '@/components/ui/flex/flex.types';
+
+export type GridCols = 1 | 2 | 3 | 4 | 5 | 6 | 12;
+
+export interface IGridProps extends ComponentPropsWithoutRef<'div'> {
+  /** Element/component to render. Defaults to `div`. */
+  as?: ElementType;
+  /** Number of equal-width columns. Use `className` for arbitrary templates. */
+  cols?: GridCols;
+  align?: FlexAlign;
+  /** Gap on both axes. */
+  gap?: Spacing;
+  /** Horizontal (column) gap. */
+  gapX?: Spacing;
+  /** Vertical (row) gap. */
+  gapY?: Spacing;
+  className?: string;
+  children?: ReactNode;
+}

--- a/frontend/src/features/invoices/components/invoice-bar/__snapshots__/invoice-bar.snapshot.test.tsx.snap
+++ b/frontend/src/features/invoices/components/invoice-bar/__snapshots__/invoice-bar.snapshot.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Invoice Bar Component renders correctly with filled props 1`] = `
 <div>
   <menu
-    class="flex items-center justify-between"
+    class="flex flex-row items-center justify-between"
     data-testid="snapshot"
   >
     <div>
@@ -28,10 +28,10 @@ exports[`Invoice Bar Component renders correctly with filled props 1`] = `
       </p>
     </div>
     <div
-      class="flex items-center gap-x-[18px] md:gap-x-10"
+      class="flex flex-row items-center gap-x-[18px] md:gap-x-10"
     >
       <div
-        class="relative grid place-items-center"
+        class="grid relative place-items-center"
       >
         <button
           class="btn btn--custom flex items-center gap-x-3 font-bold text-xl dark:text-gray-05"

--- a/frontend/src/features/invoices/components/invoice-bar/invoice-bar.tsx
+++ b/frontend/src/features/invoices/components/invoice-bar/invoice-bar.tsx
@@ -5,6 +5,9 @@ import {
 } from '@/features/invoices/components/invoice-bar/invoice-bar.types';
 import classNames from 'classnames';
 import Button from '@/components/ui/button/button';
+import Container from '@/components/ui/container/container';
+import Flex from '@/components/ui/flex/flex';
+import Grid from '@/components/ui/grid/grid';
 import Text from '@/components/ui/text/text';
 import useVisibilityToggle from '@/hooks/use-visibility-toggle';
 import Checkbox from '@/components/ui/checkbox/checkbox';
@@ -34,8 +37,8 @@ const InvoiceBar = (props: IInvoiceBarProps): JSX.Element => {
   const filterKeys: (keyof FilterState)[] = ['draft', 'pending', 'paid'];
 
   return (
-    <menu className="flex items-center justify-between" {...rest}>
-      <div>
+    <Flex align="center" as="menu" justify="between" {...rest}>
+      <Container>
         <Text className="text-gray-08 dark:text-white" tag={'h2'} variant="h2">
           {invoiceBarTitle}
         </Text>
@@ -43,9 +46,9 @@ const InvoiceBar = (props: IInvoiceBarProps): JSX.Element => {
           <span className="block md:hidden">{totalInvoicesText?.mobile}</span>
           <span className="hidden md:block">{totalInvoicesText?.desktop}</span>
         </Text>
-      </div>
-      <div className="flex items-center gap-x-[18px] md:gap-x-10">
-        <div className="relative grid place-items-center">
+      </Container>
+      <Flex align="center" className="gap-x-[18px] md:gap-x-10">
+        <Grid className="relative place-items-center">
           <Button
             className="flex items-center gap-x-3 font-bold text-xl dark:text-gray-05"
             iconRight={'chevron-down'}
@@ -69,17 +72,17 @@ const InvoiceBar = (props: IInvoiceBarProps): JSX.Element => {
               ref={elementRef}
             >
               {filterKeys.map((key) => (
-                <div key={key}>
+                <Container key={key}>
                   <Checkbox
                     label={filterStatusText[key]}
                     labelId={key}
                     onChange={handleFilterChange(key)}
                   />
-                </div>
+                </Container>
               ))}
             </div>
           )}
-        </div>
+        </Grid>
         <Button
           className="p-[6px] md:p-2 gap-x-2 items-center pr-[15px] text-xl md:text-lg"
           iconLeft={'circle-plus'}
@@ -93,8 +96,8 @@ const InvoiceBar = (props: IInvoiceBarProps): JSX.Element => {
           }
           onClick={newInvoiceHandler}
         />
-      </div>
-    </menu>
+      </Flex>
+    </Flex>
   );
 };
 

--- a/frontend/src/features/invoices/components/invoice-details/invoice-details.tsx
+++ b/frontend/src/features/invoices/components/invoice-details/invoice-details.tsx
@@ -13,6 +13,9 @@
 import { JSX } from 'react';
 import classNames from 'classnames';
 import Button from '@/components/ui/button/button';
+import Container from '@/components/ui/container/container';
+import Flex from '@/components/ui/flex/flex';
+import Grid from '@/components/ui/grid/grid';
 import Text from '@/components/ui/text/text';
 import {
   IInvoiceDetailsProps,
@@ -32,14 +35,15 @@ const AddressBlock = ({
   address: InvoiceAddress;
   className?: string;
 }): JSX.Element => (
-  <div
-    className={classNames('text-gray-07 dark:text-gray-05 flex flex-col leading-[18px]', className)}
+  <Flex
+    className={classNames('text-gray-07 dark:text-gray-05 leading-[18px]', className)}
+    direction="col"
   >
     <Text tag={'span'}>{address.street}</Text>
     <Text tag={'span'}>{address.city}</Text>
     <Text tag={'span'}>{address.postCode}</Text>
     <Text tag={'span'}>{address.country}</Text>
-  </div>
+  </Flex>
 );
 
 const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
@@ -67,15 +71,15 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
   const statusStyles = getInvoiceStatusStyles(invoiceStatus);
 
   const actions = (
-    <div className="flex items-center gap-x-2">
+    <Flex align="center" gapX={2}>
       <Button label={labels.edit} variant="secondary" onClick={onEdit} />
       <Button label={labels.delete} variant="danger" onClick={onDelete} />
       <Button label={labels.markAsPaid} variant="primary" onClick={onMarkAsPaid} />
-    </div>
+    </Flex>
   );
 
   return (
-    <div className="flex flex-col gap-y-6">
+    <Flex direction="col" gapY={6}>
       <Button
         className="flex items-center gap-x-6 w-fit font-bold text-gray-08 dark:text-white"
         iconLeft={'chevron-right'}
@@ -86,14 +90,21 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
       />
 
       {/* Status / actions bar */}
-      <div className="flex flex-col gap-y-6 md:flex-row md:items-center md:justify-between rounded-lg bg-white px-6 py-5 md:px-8 drop-shadow-lg dark:bg-blue-03">
-        <div className="flex items-center justify-between gap-x-4 md:justify-start md:gap-x-4">
+      <Flex
+        className="md:flex-row md:items-center md:justify-between rounded-lg bg-white px-6 py-5 md:px-8 drop-shadow-lg dark:bg-blue-03"
+        direction="col"
+        gapY={6}
+      >
+        <Flex align="center" className="md:justify-start md:gap-x-4" gapX={4} justify="between">
           <Text className="text-gray-07b dark:text-gray-05" tag={'span'}>
             {labels.status}
           </Text>
-          <div
+          <Flex
+            align="center"
+            gapX={1.5}
+            justify="center"
             className={classNames(
-              'flex items-center justify-center gap-x-1.5 rounded-md px-[18px] py-3 leading-none w-[104px]',
+              'rounded-md px-[18px] py-3 leading-none w-[104px]',
               statusStyles.badge
             )}
           >
@@ -101,16 +112,16 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
             <Text className="font-bold" tag={'span'}>
               {labels.statusText}
             </Text>
-          </div>
-        </div>
-        <div className="hidden md:block">{actions}</div>
-      </div>
+          </Flex>
+        </Flex>
+        <Container className="hidden md:block">{actions}</Container>
+      </Flex>
 
       {/* Invoice detail card */}
-      <div className="rounded-lg bg-white p-6 md:p-12 drop-shadow-lg dark:bg-blue-03">
+      <Container className="rounded-lg bg-white p-6 md:p-12 drop-shadow-lg dark:bg-blue-03">
         {/* Header: id + description / sender address */}
-        <div className="flex flex-col gap-y-8 md:flex-row md:justify-between">
-          <div>
+        <Flex className="md:flex-row md:justify-between" direction="col" gapY={8}>
+          <Container>
             <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
               <Text className="text-gray-06" tag={'span'}>
                 #
@@ -120,31 +131,31 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
             <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
               {description}
             </Text>
-          </div>
+          </Container>
           <AddressBlock address={senderAddress} className="md:text-right" />
-        </div>
+        </Flex>
 
         {/* Meta: dates / bill to / sent to */}
-        <div className="mt-8 grid grid-cols-2 gap-y-8 md:mt-11 md:grid-cols-3">
-          <div className="flex flex-col gap-y-8">
-            <div className="flex flex-col gap-y-3">
+        <Grid className="mt-8 md:mt-11 md:grid-cols-3" cols={2} gapY={8}>
+          <Flex direction="col" gapY={8}>
+            <Flex direction="col" gapY={3}>
               <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
                 {labels.invoiceDate}
               </Text>
               <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
                 {invoiceDate}
               </Text>
-            </div>
-            <div className="flex flex-col gap-y-3">
+            </Flex>
+            <Flex direction="col" gapY={3}>
               <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
                 {labels.paymentDue}
               </Text>
               <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
                 {paymentDue}
               </Text>
-            </div>
-          </div>
-          <div className="flex flex-col gap-y-2">
+            </Flex>
+          </Flex>
+          <Flex direction="col" gapY={2}>
             <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
               {labels.billTo}
             </Text>
@@ -152,21 +163,21 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
               {clientName}
             </Text>
             <AddressBlock address={clientAddress} className="mt-1" />
-          </div>
-          <div className="flex flex-col gap-y-3">
+          </Flex>
+          <Flex direction="col" gapY={3}>
             <Text className="text-gray-07 dark:text-gray-05" tag={'p'}>
               {labels.sentTo}
             </Text>
             <Text className="font-bold text-gray-08 dark:text-white" tag={'p'}>
               {clientEmail}
             </Text>
-          </div>
-        </div>
+          </Flex>
+        </Grid>
 
         {/* Line items */}
-        <div className="mt-11 overflow-hidden rounded-lg">
-          <div className="bg-gray-05b p-6 md:p-8 dark:bg-blue-04">
-            <div className="hidden grid-cols-[2fr_0.5fr_1fr_1fr] gap-x-4 md:grid">
+        <Container className="mt-11 overflow-hidden rounded-lg">
+          <Container className="bg-gray-05b p-6 md:p-8 dark:bg-blue-04">
+            <Grid className="hidden grid-cols-[2fr_0.5fr_1fr_1fr] md:grid" gapX={4}>
               <Text className="text-gray-07 dark:text-gray-05" tag={'span'}>
                 {labels.itemName}
               </Text>
@@ -179,11 +190,14 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
               <Text className="text-gray-07 text-right dark:text-gray-05" tag={'span'}>
                 {labels.total}
               </Text>
-            </div>
-            <ul className="flex flex-col gap-y-6 md:gap-y-8 md:mt-8">
+            </Grid>
+            <Flex as="ul" className="md:gap-y-8 md:mt-8" direction="col" gapY={6}>
               {items.map((item) => (
-                <li
-                  className="grid grid-cols-2 items-center md:grid-cols-[2fr_0.5fr_1fr_1fr] md:gap-x-4"
+                <Grid
+                  align="center"
+                  as="li"
+                  className="md:grid-cols-[2fr_0.5fr_1fr_1fr] md:gap-x-4"
+                  cols={2}
                   key={item.name}
                 >
                   <Text className="font-bold text-gray-08 dark:text-white" tag={'span'}>
@@ -208,28 +222,32 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
                   >
                     {`${currency} ${formatInvoiceAmount(getLineItemTotal(item.quantity, item.price), localeAmountDue)}`}
                   </Text>
-                </li>
+                </Grid>
               ))}
-            </ul>
-          </div>
+            </Flex>
+          </Container>
 
           {/* Amount due footer */}
-          <div className="flex items-center justify-between bg-gray-09 px-6 py-6 md:px-8 dark:bg-gray-12">
+          <Flex
+            align="center"
+            className="bg-gray-09 px-6 py-6 md:px-8 dark:bg-gray-12"
+            justify="between"
+          >
             <Text className="text-white" tag={'span'}>
               {labels.amountDue}
             </Text>
             <Text className="font-bold text-white text-2xl" tag={'span'}>
               {`${currency} ${formatInvoiceAmount(invoiceAmountDue, localeAmountDue)}`}
             </Text>
-          </div>
-        </div>
-      </div>
+          </Flex>
+        </Container>
+      </Container>
 
       {/* Actions bar (mobile: pinned below the card) */}
-      <div className="md:hidden rounded-lg bg-white px-6 py-5 drop-shadow-lg dark:bg-blue-03">
+      <Container className="md:hidden rounded-lg bg-white px-6 py-5 drop-shadow-lg dark:bg-blue-03">
         {actions}
-      </div>
-    </div>
+      </Container>
+    </Flex>
   );
 };
 

--- a/frontend/src/features/invoices/components/invoice/__snapshots__/invoice.snapshot.test.tsx.snap
+++ b/frontend/src/features/invoices/components/invoice/__snapshots__/invoice.snapshot.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`Invoice Component renders correctly with data passed to props 1`] = `
 <div>
   <div
-    class="hidden md:flex justify-between items-center py-4 px-6 bg-white drop-shadow-lg rounded-lg dark:bg-blue-03"
+    class="flex flex-row items-center justify-between hidden md:flex py-4 px-6 bg-white drop-shadow-lg rounded-lg dark:bg-blue-03"
   >
     <div
-      class="flex gap-x-11"
+      class="flex flex-row gap-x-11"
     >
       <div
-        class="flex gap-x-11 w-[256px]"
+        class="flex flex-row gap-x-11 w-[256px]"
       >
         <p
           class="text text--body text-gray-08 font-bold dark:text-white"
@@ -40,7 +40,7 @@ exports[`Invoice Component renders correctly with data passed to props 1`] = `
     </div>
     <div>
       <div
-        class="flex items-center gap-x-2"
+        class="flex flex-row items-center gap-x-2"
       >
         <p
           class="text text--body text-gray-08 font-bold text-right dark:text-white"
@@ -56,7 +56,7 @@ exports[`Invoice Component renders correctly with data passed to props 1`] = `
           class="w-[150px]"
         >
           <div
-            class="py-[14px] px-[30px] rounded-md leading-none flex items-center self-center justify-center ml-auto w-[145px] bg-gray-09a dark:bg-gray-09b text-gray-09 dark:text-gray-05"
+            class="flex flex-row items-center justify-center py-[14px] px-[30px] rounded-md leading-none self-center ml-auto w-[145px] bg-gray-09a dark:bg-gray-09b text-gray-09 dark:text-gray-05"
           >
             <span
               class="text text--body font-bold text-center flex gap-x-1.5 items-center"

--- a/frontend/src/features/invoices/components/invoice/desktop-view.tsx
+++ b/frontend/src/features/invoices/components/invoice/desktop-view.tsx
@@ -1,5 +1,7 @@
 import { JSX } from 'react';
 import { IInvoiceProps } from '@/features/invoices/types/invoice';
+import Container from '@/components/ui/container/container';
+import Flex from '@/components/ui/flex/flex';
 import Text from '@/components/ui/text/text';
 import classNames from 'classnames';
 import Button from '@/components/ui/button/button';
@@ -24,13 +26,15 @@ const DesktopView = (props: IInvoiceProps): JSX.Element => {
 
   const statusStyles = getInvoiceStatusStyles(invoiceStatus);
   return (
-    <div
-      className="hidden md:flex justify-between items-center py-4 px-6 bg-white drop-shadow-lg rounded-lg dark:bg-blue-03"
+    <Flex
+      align="center"
+      className="hidden md:flex py-4 px-6 bg-white drop-shadow-lg rounded-lg dark:bg-blue-03"
+      justify="between"
       {...rest}
     >
-      <div className="flex gap-x-11">
+      <Flex gapX={11}>
         {/* Invoice Details Section */}
-        <div className="flex gap-x-11 w-[256px]">
+        <Flex className="w-[256px]" gapX={11}>
           <Text className="text-gray-08 font-bold dark:text-white" tag={'p'}>
             <Text className="text-gray-07" tag={'span'}>
               #
@@ -43,23 +47,25 @@ const DesktopView = (props: IInvoiceProps): JSX.Element => {
             </Text>
             {invoiceDueDate}
           </Text>
-        </div>
+        </Flex>
         <Text className="text-gray-07b dark:text-white" tag={'p'}>
           {billingName}
         </Text>
-      </div>
+      </Flex>
 
       {/* Amount Due and Status Section */}
-      <div>
-        <div className="flex items-center gap-x-2">
+      <Container>
+        <Flex align="center" gapX={2}>
           <Text className="text-gray-08 font-bold text-right dark:text-white" tag={'p'}>
             <Text tag={'span'}>{getCurrencySymbol(localeAmountDue)}</Text>
             {formatInvoiceAmount(invoiceAmountDue, localeAmountDue)}
           </Text>
-          <div className="w-[150px]">
-            <div
+          <Container className="w-[150px]">
+            <Flex
+              align="center"
+              justify="center"
               className={classNames(
-                'py-[14px] px-[30px] rounded-md leading-none flex items-center self-center justify-center ml-auto w-[145px]',
+                'py-[14px] px-[30px] rounded-md leading-none self-center ml-auto w-[145px]',
                 statusStyles.badge
               )}
             >
@@ -67,14 +73,14 @@ const DesktopView = (props: IInvoiceProps): JSX.Element => {
                 <div className={classNames('w-2 h-2 rounded-full', statusStyles.dot)} />
                 {invoiceStatusText}
               </Text>
-            </div>
-          </div>
+            </Flex>
+          </Container>
 
           {/* Button Section */}
           <Button className="p-1 ml-3" iconLeft={'chevron-right'} variant="custom"></Button>
-        </div>
-      </div>
-    </div>
+        </Flex>
+      </Container>
+    </Flex>
   );
 };
 export default DesktopView;

--- a/frontend/src/features/invoices/components/invoice/invoice.tsx
+++ b/frontend/src/features/invoices/components/invoice/invoice.tsx
@@ -17,15 +17,16 @@
  */
 import { JSX } from 'react';
 import { IInvoiceProps } from '@/features/invoices/types/invoice';
+import Container from '@/components/ui/container/container';
 import MobileView from '@/features/invoices/components/invoice/mobile-view';
 import DesktopView from '@/features/invoices/components/invoice/desktop-view';
 
 const Invoice = (props: IInvoiceProps): JSX.Element => {
   return (
-    <div>
+    <Container>
       <MobileView {...props} />
       <DesktopView {...props} />
-    </div>
+    </Container>
   );
 };
 

--- a/frontend/src/features/invoices/components/invoice/mobile-view.tsx
+++ b/frontend/src/features/invoices/components/invoice/mobile-view.tsx
@@ -1,6 +1,8 @@
 import { JSX } from 'react';
 import { IInvoiceProps } from '@/features/invoices/types/invoice';
 import classNames from 'classnames';
+import Container from '@/components/ui/container/container';
+import Flex from '@/components/ui/flex/flex';
 import Text from '@/components/ui/text/text';
 import {
   formatInvoiceAmount,
@@ -23,8 +25,12 @@ const MobileView = (props: IInvoiceProps): JSX.Element => {
   const statusStyles = getInvoiceStatusStyles(invoiceStatus);
   return (
     <button className="w-full border-none">
-      <div className="md:hidden bg-white p-6 rounded-lg drop-shadow-sm flex flex-col gap-y-6 dark:bg-blue-03">
-        <div className="flex justify-between">
+      <Flex
+        className="md:hidden bg-white p-6 rounded-lg drop-shadow-sm dark:bg-blue-03"
+        direction="col"
+        gapY={6}
+      >
+        <Flex justify="between">
           <Text className="text-gray-08 font-bold dark:text-white" tag={'p'}>
             <Text className="text-gray-07" tag={'span'}>
               #
@@ -34,9 +40,9 @@ const MobileView = (props: IInvoiceProps): JSX.Element => {
           <Text className="text-gray-07b dark:text-white" tag={'p'}>
             {billingName}
           </Text>
-        </div>
-        <div className="flex justify-between">
-          <div>
+        </Flex>
+        <Flex justify="between">
+          <Container>
             <Text className="text-gray-07 flex gap-1 pb-[9px] dark:text-gray-05" tag={'p'}>
               <Text className="text-gray-06 dark:text-gray-05" tag={'span'}>
                 {dueText}
@@ -47,11 +53,13 @@ const MobileView = (props: IInvoiceProps): JSX.Element => {
               <Text tag={'span'}>{getCurrencySymbol(localeAmountDue)}</Text>
               {formatInvoiceAmount(invoiceAmountDue, localeAmountDue)}
             </Text>
-          </div>
+          </Container>
 
-          <div
+          <Flex
+            align="center"
+            justify="center"
             className={classNames(
-              'py-[14px] px-[30px] rounded-md leading-none flex items-center justify-center self-center',
+              'py-[14px] px-[30px] rounded-md leading-none self-center',
               statusStyles.badge
             )}
           >
@@ -62,9 +70,9 @@ const MobileView = (props: IInvoiceProps): JSX.Element => {
               <div className={classNames('w-2 h-2 rounded-full', statusStyles.dot)} />
               {invoiceStatusText}
             </Text>
-          </div>
-        </div>
-      </div>
+          </Flex>
+        </Flex>
+      </Flex>
     </button>
   );
 };


### PR DESCRIPTION
Adds reusable layout primitives and refactors container divs across the app to use them.

## Changes
- New `Container`, `Flex`, and `Grid` components under `components/ui`. Each is polymorphic (`as` prop), forwards `className` and arbitrary props, and maps scalar props (direction, align, justify, wrap, gap/gapX/gapY, cols) to static Tailwind classes so the compiler always picks them up.
- Storybook stories for all three under a new `Utils` section, with explicit argTypes so every custom prop is documented (description, control, type) and interactive in the Docs tab.
- Co-located unit and snapshot tests for each primitive.
- Refactored layout container divs to the primitives in home-view, invoice, desktop-view, mobile-view, invoice-bar, invoice-details, main-menu, and checkbox. Responsive and arbitrary-value classes stay in `className`, per the scalar-props approach.

Presentation-only divs that are not layout containers (status dots), the filter dropdown that needs a ref, and Storybook decorators are intentionally left as plain elements.

Behavior is preserved: component snapshots were regenerated for the equivalent markup, and the compiled CSS keeps `hidden` after `flex`/`grid` so responsive visibility (hidden md:flex, hidden md:grid) still works after the primitives add a base display class.