### PR TITLE
fix(button): route mobile invoice card through the Button component

### DIFF
--- a/frontend/src/components/ui/button/button.test.tsx
+++ b/frontend/src/components/ui/button/button.test.tsx
@@ -64,6 +64,17 @@ describe('Button Component - Unit Tests', () => {
     expect(svg).toBeInTheDocument();
   });
 
+  it('renders custom `children` content', () => {
+    render(
+      <Button data-testid={testId} variant="custom">
+        <span>Custom content</span>
+      </Button>
+    );
+    const element = screen.getByTestId(testId);
+    expect(element).toHaveClass('btn btn--custom');
+    expect(screen.getByText('Custom content')).toBeInTheDocument();
+  });
+
   it('renders disbled button when `disabled` is passed and does not fire click event', () => {
     const handleClick = jest.fn();
     render(<Button data-testid={testId} disabled onClick={handleClick} />);

--- a/frontend/src/components/ui/button/button.tsx
+++ b/frontend/src/components/ui/button/button.tsx
@@ -12,6 +12,7 @@
  * @param label
  * @param variant - default: 'primary'
  * @param className
+ * @param children - custom button content (rendered after any icon/label)
  *
  * @returns {JSX.Element}
  */
@@ -31,6 +32,7 @@ const Button = (props: IButtonProps): JSX.Element => {
     label,
     variant = 'primary',
     className: classNameProp,
+    children,
     ...rest
   } = props;
 
@@ -59,6 +61,8 @@ const Button = (props: IButtonProps): JSX.Element => {
       ) : (
         iconRight
       )}
+
+      {children}
     </>
   );
 

--- a/frontend/src/features/invoices/components/invoice/mobile-view.tsx
+++ b/frontend/src/features/invoices/components/invoice/mobile-view.tsx
@@ -1,6 +1,7 @@
 import { JSX } from 'react';
 import { IInvoiceProps } from '@/features/invoices/types/invoice';
 import classNames from 'classnames';
+import Button from '@/components/ui/button/button';
 import Container from '@/components/ui/container/container';
 import Flex from '@/components/ui/flex/flex';
 import Text from '@/components/ui/text/text';
@@ -24,7 +25,7 @@ const MobileView = (props: IInvoiceProps): JSX.Element => {
 
   const statusStyles = getInvoiceStatusStyles(invoiceStatus);
   return (
-    <button className="w-full border-none">
+    <Button className="w-full border-none" variant="custom">
       <Flex
         className="md:hidden bg-white p-6 rounded-lg drop-shadow-sm dark:bg-blue-03"
         direction="col"
@@ -73,7 +74,7 @@ const MobileView = (props: IInvoiceProps): JSX.Element => {
           </Flex>
         </Flex>
       </Flex>
-    </button>
+    </Button>
   );
 };
 

--- a/frontend/src/styles/ui/button.css
+++ b/frontend/src/styles/ui/button.css
@@ -7,7 +7,8 @@
     .icon {
       @apply max-w-full;
     }
-    span {
+    /* Only the button's own label span, not nested content passed as children. */
+    & > span {
       @apply w-full leading-none;
     }
   }


### PR DESCRIPTION
Replaces the last raw button element with the shared Button component so all buttons go through the design system.

## Changes
- Convert the mobile invoice card wrapper from a raw button to the Button component (variant custom).
- Add children support to Button so it can wrap custom content, not just icon/label. Existing usages are unaffected.
- Scope the label span rule from a descendant selector to a direct child (.btn > span) so it no longer leaks into nested content such as the card's Text spans.

Behavior is preserved. The mobile card also now gets the standard pointer cursor. Verified with lint, tests, next build and storybook build.