### PR TITLE
feat(invoices): open invoice detail view on click with i18n

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -16,5 +16,24 @@
     "statusPending": "Pending",
     "statusPaid": "Paid",
     "due": "Due"
+  },
+  "InvoiceDetails": {
+    "goBack": "Go back",
+    "status": "Status",
+    "edit": "Edit",
+    "delete": "Delete",
+    "markAsPaid": "Mark as Paid",
+    "billTo": "Bill To",
+    "sentTo": "Sent to",
+    "invoiceDate": "Invoice Date",
+    "paymentDue": "Payment Due",
+    "itemName": "Item Name",
+    "quantity": "QTY.",
+    "price": "Price",
+    "total": "Total",
+    "amountDue": "Amount Due",
+    "statusDraft": "Draft",
+    "statusPending": "Pending",
+    "statusPaid": "Paid"
   }
 }

--- a/frontend/src/app/[locale]/home-view.tsx
+++ b/frontend/src/app/[locale]/home-view.tsx
@@ -2,48 +2,13 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import MainMenu from '@/components/layouts/main-menu/main-menu';
-import Container from '@/components/ui/container/container';
+import { Link } from '@/lib/i18n/routing';
 import Flex from '@/components/ui/flex/flex';
 import InvoiceBar from '@/features/invoices/components/invoice-bar/invoice-bar';
 import type { FilterState } from '@/features/invoices/components/invoice-bar/invoice-bar.types';
 import Invoice from '@/features/invoices/components/invoice/invoice';
+import { sampleInvoices } from '@/features/invoices/data/sample-invoices';
 import { InvoiceStatus } from '@/features/invoices/types/invoice';
-import { useDarkMode } from '@/hooks/use-dark-mode';
-
-interface SampleInvoice {
-  invoiceId: string;
-  billingName: string;
-  invoiceDueDate: string;
-  invoiceAmountDue: number;
-  invoiceStatus: InvoiceStatus;
-}
-
-// Sample data stands in for the (not yet built) data layer; when an API is
-// added this should come from `features/invoices/api`.
-const SAMPLE_INVOICES: SampleInvoice[] = [
-  {
-    invoiceId: 'RT3080',
-    billingName: 'Jensen Huang',
-    invoiceDueDate: '19 Aug 2021',
-    invoiceAmountDue: 1800.9,
-    invoiceStatus: InvoiceStatus.PAID,
-  },
-  {
-    invoiceId: 'XM9141',
-    billingName: 'Alex Grim',
-    invoiceDueDate: '20 Sep 2021',
-    invoiceAmountDue: 556.0,
-    invoiceStatus: InvoiceStatus.PENDING,
-  },
-  {
-    invoiceId: 'RG0314',
-    billingName: 'John Morrison',
-    invoiceDueDate: '01 Oct 2021',
-    invoiceAmountDue: 14002.33,
-    invoiceStatus: InvoiceStatus.DRAFT,
-  },
-];
 
 const STATUS_TO_FILTER_KEY: Record<InvoiceStatus, keyof FilterState> = {
   [InvoiceStatus.DRAFT]: 'draft',
@@ -53,13 +18,14 @@ const STATUS_TO_FILTER_KEY: Record<InvoiceStatus, keyof FilterState> = {
 
 const HomeView = () => {
   const t = useTranslations('Dashboard');
-  const tMenu = useTranslations('MainMenu');
-  const { theme, toggleTheme } = useDarkMode();
   const [filters, setFilters] = useState<FilterState>({
     draft: false,
     pending: false,
     paid: false,
   });
+
+  // @TODO: wire up new-invoice creation once the create flow exists.
+  const handleNewInvoice = () => {};
 
   const statusLabels: Record<InvoiceStatus, string> = {
     [InvoiceStatus.DRAFT]: t('statusDraft'),
@@ -68,54 +34,48 @@ const HomeView = () => {
   };
 
   const noFilterActive = !filters.draft && !filters.pending && !filters.paid;
-  const visibleInvoices = SAMPLE_INVOICES.filter(
-    (invoice) => noFilterActive || filters[STATUS_TO_FILTER_KEY[invoice.invoiceStatus]]
+  // @TODO: replace sampleInvoices with data from `features/invoices/api` once a backend exists.
+  const visibleInvoices = sampleInvoices.filter(
+    (invoice) => noFilterActive || filters[STATUS_TO_FILTER_KEY[invoice.status]]
   );
 
   return (
-    <Container className="min-h-screen lg:pl-25">
-      <MainMenu
-        darkmode={theme}
-        darkmodeBtn={{ darkAria: tMenu('switchToDark'), lightAria: tMenu('switchToLight') }}
-        darkmodeToggle={toggleTheme}
-        profile={{ profileImageAlt: tMenu('profileImageAlt') }}
+    <Flex className="mx-auto max-w-250" direction="col" gapY={8}>
+      <InvoiceBar
+        filters={filters}
+        filterStatusBtn={{ mobile: t('filterMobile'), desktop: t('filterDesktop') }}
+        invoiceBarTitle={t('title')}
+        newInvoiceBtn={{ mobile: t('newInvoiceMobile'), desktop: t('newInvoiceDesktop') }}
+        newInvoiceHandler={handleNewInvoice}
+        setFilters={setFilters}
+        filterStatusText={{
+          draft: t('statusDraft'),
+          pending: t('statusPending'),
+          paid: t('statusPaid'),
+        }}
+        totalInvoicesText={{
+          mobile: t('totalMobile', { count: sampleInvoices.length }),
+          desktop: t('totalDesktop', { count: sampleInvoices.length }),
+        }}
       />
-      <Flex
-        as="main"
-        className="mx-auto max-w-250 px-6 py-8 md:py-12 lg:py-16"
-        direction="col"
-        gapY={8}
-      >
-        <InvoiceBar
-          filters={filters}
-          filterStatusBtn={{ mobile: t('filterMobile'), desktop: t('filterDesktop') }}
-          invoiceBarTitle={t('title')}
-          newInvoiceBtn={{ mobile: t('newInvoiceMobile'), desktop: t('newInvoiceDesktop') }}
-          newInvoiceHandler={() => {}}
-          setFilters={setFilters}
-          filterStatusText={{
-            draft: t('statusDraft'),
-            pending: t('statusPending'),
-            paid: t('statusPaid'),
-          }}
-          totalInvoicesText={{
-            mobile: t('totalMobile', { count: SAMPLE_INVOICES.length }),
-            desktop: t('totalDesktop', { count: SAMPLE_INVOICES.length }),
-          }}
-        />
-        <Flex as="ul" direction="col" gapY={4}>
-          {visibleInvoices.map((invoice) => (
-            <li key={invoice.invoiceId}>
+      <Flex as="ul" direction="col" gapY={4}>
+        {visibleInvoices.map((invoice) => (
+          <li key={invoice.id}>
+            <Link className="block" href={`/invoices/${invoice.id}`}>
               <Invoice
-                {...invoice}
+                billingName={invoice.clientName}
                 dueText={t('due')}
-                invoiceStatusText={statusLabels[invoice.invoiceStatus]}
+                invoiceAmountDue={invoice.amountDue}
+                invoiceDueDate={invoice.paymentDue}
+                invoiceId={invoice.id}
+                invoiceStatus={invoice.status}
+                invoiceStatusText={statusLabels[invoice.status]}
               />
-            </li>
-          ))}
-        </Flex>
+            </Link>
+          </li>
+        ))}
       </Flex>
-    </Container>
+    </Flex>
   );
 };
 

--- a/frontend/src/app/[locale]/invoices/[id]/invoice-detail-view.tsx
+++ b/frontend/src/app/[locale]/invoices/[id]/invoice-detail-view.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { JSX } from 'react';
+import { useTranslations } from 'next-intl';
+import { useRouter } from '@/lib/i18n/routing';
+import Container from '@/components/ui/container/container';
+import InvoiceDetails from '@/features/invoices/components/invoice-details/invoice-details';
+import { Invoice, InvoiceStatus } from '@/features/invoices/types/invoice';
+
+const InvoiceDetailView = ({ invoice }: { invoice: Invoice }): JSX.Element => {
+  const t = useTranslations('InvoiceDetails');
+  const router = useRouter();
+
+  const statusText: Record<InvoiceStatus, string> = {
+    [InvoiceStatus.DRAFT]: t('statusDraft'),
+    [InvoiceStatus.PENDING]: t('statusPending'),
+    [InvoiceStatus.PAID]: t('statusPaid'),
+  };
+
+  return (
+    <Container className="mx-auto max-w-[730px]">
+      {/* @TODO: wire onEdit/onDelete/onMarkAsPaid once the invoice mutation flow exists. */}
+      <InvoiceDetails
+        clientAddress={invoice.clientAddress}
+        clientEmail={invoice.clientEmail}
+        clientName={invoice.clientName}
+        description={invoice.description}
+        invoiceAmountDue={invoice.amountDue}
+        invoiceDate={invoice.invoiceDate}
+        invoiceId={invoice.id}
+        invoiceStatus={invoice.status}
+        items={invoice.items}
+        paymentDue={invoice.paymentDue}
+        senderAddress={invoice.senderAddress}
+        labels={{
+          goBack: t('goBack'),
+          status: t('status'),
+          statusText: statusText[invoice.status],
+          edit: t('edit'),
+          delete: t('delete'),
+          markAsPaid: t('markAsPaid'),
+          billTo: t('billTo'),
+          sentTo: t('sentTo'),
+          invoiceDate: t('invoiceDate'),
+          paymentDue: t('paymentDue'),
+          itemName: t('itemName'),
+          quantity: t('quantity'),
+          price: t('price'),
+          total: t('total'),
+          amountDue: t('amountDue'),
+        }}
+        onGoBack={() => router.push('/')}
+      />
+    </Container>
+  );
+};
+
+export default InvoiceDetailView;

--- a/frontend/src/app/[locale]/invoices/[id]/page.tsx
+++ b/frontend/src/app/[locale]/invoices/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation';
+import { getInvoiceById } from '@/features/invoices/data/sample-invoices';
+import InvoiceDetailView from './invoice-detail-view';
+
+export default async function InvoicePage({
+  params,
+}: {
+  params: Promise<{ locale: string; id: string }>;
+}) {
+  const { id } = await params;
+  // @TODO: fetch the invoice from `features/invoices/api` once a backend exists.
+  const invoice = getInvoiceById(id);
+
+  if (!invoice) {
+    notFound();
+  }
+
+  return <InvoiceDetailView invoice={invoice} />;
+}

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next';
 import React from 'react';
 import '@/styles/app.css';
 import { AppProvider } from '@/app/provider';
+import AppShell from '@/components/layouts/app-shell/app-shell';
 import { League_Spartan } from 'next/font/google';
 
 export const dynamic = 'force-dynamic';
@@ -40,7 +41,9 @@ export default async function LocaleLayout({
     <html className={`${leagueSpartan.variable} font-sans`} lang={locale} suppressHydrationWarning>
       <body className="bg-neutral-11 dark:bg-gray-12">
         <NextIntlClientProvider messages={messages}>
-          <AppProvider>{children}</AppProvider>
+          <AppProvider>
+            <AppShell>{children}</AppShell>
+          </AppProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/frontend/src/components/layouts/app-shell/app-shell.tsx
+++ b/frontend/src/components/layouts/app-shell/app-shell.tsx
@@ -1,0 +1,38 @@
+/**
+ * @name AppShell
+ * @author Tyrell Curry <tyrellcurryio@gmail.com>
+ *
+ * App shell shared by every page: the persistent MainMenu sidebar (wired to
+ * dark mode + menu translations) and a padded `main` region for page content.
+ * Pages provide their own max-width container inside `children`.
+ *
+ * @param children
+ *
+ * @returns {JSX.Element}
+ */
+'use client';
+
+import { JSX, ReactNode } from 'react';
+import { useTranslations } from 'next-intl';
+import MainMenu from '@/components/layouts/main-menu/main-menu';
+import Container from '@/components/ui/container/container';
+import { useDarkMode } from '@/hooks/use-dark-mode';
+
+const AppShell = ({ children }: { children: ReactNode }): JSX.Element => {
+  const tMenu = useTranslations('MainMenu');
+  const { theme, toggleTheme } = useDarkMode();
+
+  return (
+    <Container className="min-h-screen lg:pl-25">
+      <MainMenu
+        darkmode={theme}
+        darkmodeBtn={{ darkAria: tMenu('switchToDark'), lightAria: tMenu('switchToLight') }}
+        darkmodeToggle={toggleTheme}
+        profile={{ profileImageAlt: tMenu('profileImageAlt') }}
+      />
+      <main className="px-6 py-8 md:py-12 lg:py-16">{children}</main>
+    </Container>
+  );
+};
+
+export default AppShell;

--- a/frontend/src/features/invoices/components/invoice-details/invoice-details.types.ts
+++ b/frontend/src/features/invoices/components/invoice-details/invoice-details.types.ts
@@ -1,17 +1,11 @@
-import { InvoiceLocale, InvoiceStatus } from '@/features/invoices/types/invoice';
+import {
+  InvoiceAddress,
+  InvoiceLineItem,
+  InvoiceLocale,
+  InvoiceStatus,
+} from '@/features/invoices/types/invoice';
 
-export interface InvoiceAddress {
-  street: string;
-  city: string;
-  postCode: string;
-  country: string;
-}
-
-export interface InvoiceLineItem {
-  name: string;
-  quantity: number;
-  price: number;
-}
+export type { InvoiceAddress, InvoiceLineItem };
 
 /** All user-facing copy, passed in so the component stays presentation-only. */
 export interface InvoiceDetailsLabels {

--- a/frontend/src/features/invoices/components/invoice/__snapshots__/invoice.snapshot.test.tsx.snap
+++ b/frontend/src/features/invoices/components/invoice/__snapshots__/invoice.snapshot.test.tsx.snap
@@ -68,13 +68,9 @@ exports[`Invoice Component renders correctly with data passed to props 1`] = `
             </span>
           </div>
         </div>
-        <button
-          class="btn btn--custom p-1 ml-3"
-        >
-          <svg
-            class="icon"
-          />
-        </button>
+        <svg
+          class="ml-3"
+        />
       </div>
     </div>
   </div>

--- a/frontend/src/features/invoices/components/invoice/desktop-view.tsx
+++ b/frontend/src/features/invoices/components/invoice/desktop-view.tsx
@@ -4,7 +4,7 @@ import Container from '@/components/ui/container/container';
 import Flex from '@/components/ui/flex/flex';
 import Text from '@/components/ui/text/text';
 import classNames from 'classnames';
-import Button from '@/components/ui/button/button';
+import Icon from '@/components/ui/icon/icon';
 import {
   formatInvoiceAmount,
   getCurrencySymbol,
@@ -76,8 +76,8 @@ const DesktopView = (props: IInvoiceProps): JSX.Element => {
             </Flex>
           </Container>
 
-          {/* Button Section */}
-          <Button className="p-1 ml-3" iconLeft={'chevron-right'} variant="custom"></Button>
+          {/* Chevron affordance (the whole row is a link) */}
+          <Icon className="ml-3" name="chevron-right" />
         </Flex>
       </Container>
     </Flex>

--- a/frontend/src/features/invoices/components/invoice/mobile-view.tsx
+++ b/frontend/src/features/invoices/components/invoice/mobile-view.tsx
@@ -1,7 +1,6 @@
 import { JSX } from 'react';
 import { IInvoiceProps } from '@/features/invoices/types/invoice';
 import classNames from 'classnames';
-import Button from '@/components/ui/button/button';
 import Container from '@/components/ui/container/container';
 import Flex from '@/components/ui/flex/flex';
 import Text from '@/components/ui/text/text';
@@ -25,56 +24,54 @@ const MobileView = (props: IInvoiceProps): JSX.Element => {
 
   const statusStyles = getInvoiceStatusStyles(invoiceStatus);
   return (
-    <Button className="w-full border-none" variant="custom">
-      <Flex
-        className="md:hidden bg-white p-6 rounded-lg drop-shadow-sm dark:bg-blue-03"
-        direction="col"
-        gapY={6}
-      >
-        <Flex justify="between">
+    <Flex
+      className="md:hidden bg-white p-6 rounded-lg drop-shadow-sm dark:bg-blue-03"
+      direction="col"
+      gapY={6}
+    >
+      <Flex justify="between">
+        <Text className="text-gray-08 font-bold dark:text-white" tag={'p'}>
+          <Text className="text-gray-07" tag={'span'}>
+            #
+          </Text>
+          {invoiceId}
+        </Text>
+        <Text className="text-gray-07b dark:text-white" tag={'p'}>
+          {billingName}
+        </Text>
+      </Flex>
+      <Flex justify="between">
+        <Container>
+          <Text className="text-gray-07 flex gap-1 pb-[9px] dark:text-gray-05" tag={'p'}>
+            <Text className="text-gray-06 dark:text-gray-05" tag={'span'}>
+              {dueText}
+            </Text>
+            {invoiceDueDate}
+          </Text>
           <Text className="text-gray-08 font-bold dark:text-white" tag={'p'}>
-            <Text className="text-gray-07" tag={'span'}>
-              #
-            </Text>
-            {invoiceId}
+            <Text tag={'span'}>{getCurrencySymbol(localeAmountDue)}</Text>
+            {formatInvoiceAmount(invoiceAmountDue, localeAmountDue)}
           </Text>
-          <Text className="text-gray-07b dark:text-white" tag={'p'}>
-            {billingName}
-          </Text>
-        </Flex>
-        <Flex justify="between">
-          <Container>
-            <Text className="text-gray-07 flex gap-1 pb-[9px] dark:text-gray-05" tag={'p'}>
-              <Text className="text-gray-06 dark:text-gray-05" tag={'span'}>
-                {dueText}
-              </Text>
-              {invoiceDueDate}
-            </Text>
-            <Text className="text-gray-08 font-bold dark:text-white" tag={'p'}>
-              <Text tag={'span'}>{getCurrencySymbol(localeAmountDue)}</Text>
-              {formatInvoiceAmount(invoiceAmountDue, localeAmountDue)}
-            </Text>
-          </Container>
+        </Container>
 
-          <Flex
-            align="center"
-            justify="center"
-            className={classNames(
-              'py-[14px] px-[30px] rounded-md leading-none self-center',
-              statusStyles.badge
-            )}
+        <Flex
+          align="center"
+          justify="center"
+          className={classNames(
+            'py-[14px] px-[30px] rounded-md leading-none self-center',
+            statusStyles.badge
+          )}
+        >
+          <Text
+            className="font-bold text-center flex gap-x-1.5 items-center text-[15px]"
+            tag={'span'}
           >
-            <Text
-              className="font-bold text-center flex gap-x-1.5 items-center text-[15px]"
-              tag={'span'}
-            >
-              <div className={classNames('w-2 h-2 rounded-full', statusStyles.dot)} />
-              {invoiceStatusText}
-            </Text>
-          </Flex>
+            <div className={classNames('w-2 h-2 rounded-full', statusStyles.dot)} />
+            {invoiceStatusText}
+          </Text>
         </Flex>
       </Flex>
-    </Button>
+    </Flex>
   );
 };
 

--- a/frontend/src/features/invoices/data/sample-invoices.test.ts
+++ b/frontend/src/features/invoices/data/sample-invoices.test.ts
@@ -1,0 +1,24 @@
+import { getInvoiceById, sampleInvoices } from '@/features/invoices/data/sample-invoices';
+import { getLineItemTotal } from '@/features/invoices/utils/get-line-item-total';
+
+describe('sampleInvoices', () => {
+  it('has a stated amount due matching the sum of its line items', () => {
+    sampleInvoices.forEach((invoice) => {
+      const total = invoice.items.reduce(
+        (sum, item) => sum + getLineItemTotal(item.quantity, item.price),
+        0
+      );
+      expect(invoice.amountDue).toBeCloseTo(total, 2);
+    });
+  });
+});
+
+describe('getInvoiceById', () => {
+  it('returns the matching invoice', () => {
+    expect(getInvoiceById('XM9141')?.clientName).toBe('Alex Grim');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(getInvoiceById('NOPE00')).toBeUndefined();
+  });
+});

--- a/frontend/src/features/invoices/data/sample-invoices.ts
+++ b/frontend/src/features/invoices/data/sample-invoices.ts
@@ -1,0 +1,85 @@
+import { Invoice, InvoiceStatus } from '@/features/invoices/types/invoice';
+
+/**
+ * Sample invoice data. This stands in for the data layer.
+ *
+ * @TODO: replace with fetchers/hooks in `features/invoices/api` once a backend exists.
+ */
+export const sampleInvoices: Invoice[] = [
+  {
+    id: 'RT3080',
+    description: 'Re-branding',
+    status: InvoiceStatus.PAID,
+    invoiceDate: '18 Jul 2021',
+    paymentDue: '19 Aug 2021',
+    senderAddress: {
+      street: '19 Union Terrace',
+      city: 'London',
+      postCode: 'E1 3EZ',
+      country: 'United Kingdom',
+    },
+    clientName: 'Jensen Huang',
+    clientEmail: 'jensenh@mail.com',
+    clientAddress: {
+      street: '106 Kendell Street',
+      city: 'Sharrington',
+      postCode: 'NR24 5WQ',
+      country: 'United Kingdom',
+    },
+    items: [{ name: 'Brand Guidelines', quantity: 1, price: 1800.9 }],
+    amountDue: 1800.9,
+  },
+  {
+    id: 'XM9141',
+    description: 'Graphic Design',
+    status: InvoiceStatus.PENDING,
+    invoiceDate: '21 Aug 2021',
+    paymentDue: '20 Sep 2021',
+    senderAddress: {
+      street: '19 Union Terrace',
+      city: 'London',
+      postCode: 'E1 3EZ',
+      country: 'United Kingdom',
+    },
+    clientName: 'Alex Grim',
+    clientEmail: 'alexgrim@mail.com',
+    clientAddress: {
+      street: '84 Church Way',
+      city: 'Bradford',
+      postCode: 'BD1 9PB',
+      country: 'United Kingdom',
+    },
+    items: [
+      { name: 'Banner Design', quantity: 1, price: 156.0 },
+      { name: 'Email Design', quantity: 2, price: 200.0 },
+    ],
+    amountDue: 556.0,
+  },
+  {
+    id: 'RG0314',
+    description: 'Website Redesign',
+    status: InvoiceStatus.DRAFT,
+    invoiceDate: '30 Aug 2021',
+    paymentDue: '01 Oct 2021',
+    senderAddress: {
+      street: '19 Union Terrace',
+      city: 'London',
+      postCode: 'E1 3EZ',
+      country: 'United Kingdom',
+    },
+    clientName: 'John Morrison',
+    clientEmail: 'jm@myco.com',
+    clientAddress: {
+      street: '79 Dover Road',
+      city: 'Westhall',
+      postCode: 'IP19 3PF',
+      country: 'United Kingdom',
+    },
+    items: [{ name: 'Website Redesign', quantity: 1, price: 14002.33 }],
+    amountDue: 14002.33,
+  },
+];
+
+/** Returns the invoice with the given id, or `undefined` if none matches. */
+export const getInvoiceById = (id: string): Invoice | undefined =>
+  sampleInvoices.find((invoice) => invoice.id === id);

--- a/frontend/src/features/invoices/types/invoice.ts
+++ b/frontend/src/features/invoices/types/invoice.ts
@@ -6,6 +6,34 @@ export enum InvoiceStatus {
 
 export type InvoiceLocale = 'en' | 'fr';
 
+export interface InvoiceAddress {
+  street: string;
+  city: string;
+  postCode: string;
+  country: string;
+}
+
+export interface InvoiceLineItem {
+  name: string;
+  quantity: number;
+  price: number;
+}
+
+/** Full invoice record @TODO:(stands in for the API model until a backend exists). */
+export interface Invoice {
+  id: string;
+  description: string;
+  status: InvoiceStatus;
+  invoiceDate: string;
+  paymentDue: string;
+  senderAddress: InvoiceAddress;
+  clientName: string;
+  clientEmail: string;
+  clientAddress: InvoiceAddress;
+  items: InvoiceLineItem[];
+  amountDue: number;
+}
+
 export interface IInvoiceProps {
   invoiceId: string;
   invoiceDueDate: string;


### PR DESCRIPTION
Makes each invoice in the list clickable and wires it to a localized detail route.

## Changes
- Whole invoice is now a link. The mobile card and desktop row no longer contain their own buttons (the desktop chevron is now a decorative icon), so each invoice can be wrapped in a next-intl Link to /invoices/[id] without nesting interactive elements.
- New route app/[locale]/invoices/[id] that looks up the invoice and renders the InvoiceDetails view with next-intl messages (new InvoiceDetails namespace). Unknown ids return notFound.
- Added an AppShell layout component so the MainMenu sidebar is shared by every page via the root layout, instead of being rendered inside the home view.
- Added an Invoice domain model and a features/invoices/data sample data source (getInvoiceById) that both the list and detail view read from. Marked all placeholder data and unwired handlers with @TODO.

Verified with lint, types, 84 tests, next build and storybook build, plus a runtime check: home and detail routes return 200 with the correct localized content, and an unknown id returns 404.