### PR TITLE
chore(font): switch typeface to lexend

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -3,12 +3,12 @@ import type { Preview } from '@storybook/nextjs';
 import '../src/styles/app.css';
 import { withThemeByClassName } from '@storybook/addon-themes';
 
-import { League_Spartan } from 'next/font/google';
+import { Lexend } from 'next/font/google';
 
-const leagueSpartan = League_Spartan({
+const lexend = Lexend({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-leaguespartan',
+  variable: '--font-lexend',
 });
 
 const preview: Preview = {
@@ -21,7 +21,7 @@ const preview: Preview = {
       defaultTheme: 'Light',
     }),
     (Story) => (
-      <main className={`${leagueSpartan.variable} font-sans`}>
+      <main className={`${lexend.variable} font-sans`}>
         <Story />
       </main>
     ),

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -7,14 +7,14 @@ import React from 'react';
 import '@/styles/app.css';
 import { AppProvider } from '@/app/provider';
 import AppShell from '@/components/layouts/app-shell/app-shell';
-import { League_Spartan } from 'next/font/google';
+import { Lexend } from 'next/font/google';
 
 export const dynamic = 'force-dynamic';
 
-const leagueSpartan = League_Spartan({
+const lexend = Lexend({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-leaguespartan',
+  variable: '--font-lexend',
 });
 
 export const metadata: Metadata = {
@@ -38,7 +38,7 @@ export default async function LocaleLayout({
   const messages = await getMessages();
 
   return (
-    <html className={`${leagueSpartan.variable} font-sans`} lang={locale} suppressHydrationWarning>
+    <html className={`${lexend.variable} font-sans`} lang={locale} suppressHydrationWarning>
       <body className="bg-neutral-11 dark:bg-gray-12">
         <NextIntlClientProvider messages={messages}>
           <AppProvider>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -10,7 +10,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['var(--font-leaguespartan)'],
+        sans: ['var(--font-lexend)'],
       },
       screens: {
         xs: '414px',


### PR DESCRIPTION
Switches the app typeface to Lexend.

League Spartan renders with extra half-leading under its glyphs, which left text slightly misaligned. Lexend has even vertical metrics that resolve this without any trimming workarounds, and renders consistently across browsers.

Updated the font in the root layout, the Storybook preview, and the Tailwind sans family (var --font-lexend). Verified with next build, storybook build and the test suite.