### PR TITLE
feat(invoices): add divider above invoice details meta section

### DIFF
--- a/frontend/src/features/invoices/components/invoice-details/invoice-details.tsx
+++ b/frontend/src/features/invoices/components/invoice-details/invoice-details.tsx
@@ -135,6 +135,9 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
           <AddressBlock address={senderAddress} className="md:text-right" />
         </Flex>
 
+        {/* Divider between the header row and the invoice meta */}
+        <hr className="mt-8 md:mt-11 h-px border-0 bg-gray-05 dark:bg-blue-04" />
+
         {/* Meta: dates / bill to / sent to */}
         <Grid className="mt-8 md:mt-11 md:grid-cols-3" cols={2} gapY={8}>
           <Flex direction="col" gapY={8}>


### PR DESCRIPTION
Adds a subtle divider in the invoice details card between the header row (invoice id, description and sender address) and the meta section (invoice date, bill to, sent to).

Uses existing tokens (gray-05 in light mode, blue-04 in dark) with symmetric spacing, rendered as a semantic hr. Verified with lint, types, tests and storybook build.