### PR TITLE
feat(invoices): add delete confirmation dialog

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -66,5 +66,11 @@
     "term7": "Net 7 Days",
     "term14": "Net 14 Days",
     "term30": "Net 30 Days"
+  },
+  "DeleteInvoice": {
+    "title": "Confirm Deletion",
+    "message": "Are you sure you want to delete invoice #{id}? This action cannot be undone.",
+    "cancel": "Cancel",
+    "delete": "Delete"
   }
 }

--- a/frontend/src/app/[locale]/invoices/[id]/invoice-detail-view.tsx
+++ b/frontend/src/app/[locale]/invoices/[id]/invoice-detail-view.tsx
@@ -4,6 +4,7 @@ import { JSX, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from '@/lib/i18n/routing';
 import Container from '@/components/ui/container/container';
+import DeleteInvoiceDialog from '@/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog';
 import InvoiceDetails from '@/features/invoices/components/invoice-details/invoice-details';
 import InvoiceFormDrawer from '@/features/invoices/components/invoice-form-drawer/invoice-form-drawer';
 import type { InvoiceFormValues } from '@/features/invoices/components/invoice-form-drawer/invoice-form-drawer.types';
@@ -13,9 +14,11 @@ import { invoiceToFormValues } from '@/features/invoices/utils/invoice-form-valu
 
 const InvoiceDetailView = ({ invoice }: { invoice: Invoice }): JSX.Element => {
   const t = useTranslations('InvoiceDetails');
+  const tDelete = useTranslations('DeleteInvoice');
   const router = useRouter();
   const { labels: formLabels, paymentTermOptions } = useInvoiceFormLabels();
   const [isEditing, setIsEditing] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const formValues = useMemo(() => invoiceToFormValues(invoice), [invoice]);
 
@@ -30,9 +33,15 @@ const InvoiceDetailView = ({ invoice }: { invoice: Invoice }): JSX.Element => {
     setIsEditing(false);
   };
 
+  // @TODO: delete via `features/invoices/api` once a backend exists.
+  const handleConfirmDelete = () => {
+    setIsDeleting(false);
+    router.push('/');
+  };
+
   return (
     <Container className="mx-auto max-w-[730px]">
-      {/* @TODO: wire onDelete/onMarkAsPaid once the invoice mutation flow exists. */}
+      {/* @TODO: wire onMarkAsPaid once the invoice mutation flow exists. */}
       <InvoiceDetails
         clientAddress={invoice.clientAddress}
         clientEmail={invoice.clientEmail}
@@ -62,6 +71,7 @@ const InvoiceDetailView = ({ invoice }: { invoice: Invoice }): JSX.Element => {
           total: t('total'),
           amountDue: t('amountDue'),
         }}
+        onDelete={() => setIsDeleting(true)}
         onEdit={() => setIsEditing(true)}
         onGoBack={() => router.push('/')}
       />
@@ -75,6 +85,18 @@ const InvoiceDetailView = ({ invoice }: { invoice: Invoice }): JSX.Element => {
         paymentTermOptions={paymentTermOptions}
         onClose={() => setIsEditing(false)}
         onSubmit={handleSubmit}
+      />
+
+      <DeleteInvoiceDialog
+        open={isDeleting}
+        labels={{
+          title: tDelete('title'),
+          message: tDelete('message', { id: invoice.id }),
+          cancel: tDelete('cancel'),
+          delete: tDelete('delete'),
+        }}
+        onCancel={() => setIsDeleting(false)}
+        onConfirm={handleConfirmDelete}
       />
     </Container>
   );

--- a/frontend/src/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog.stories.tsx
+++ b/frontend/src/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { fn } from 'storybook/test';
+
+import DeleteInvoiceDialog from '@/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog';
+
+const meta = {
+  title: 'Features/Invoices/Delete Invoice Dialog',
+  component: DeleteInvoiceDialog,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  args: {
+    open: true,
+    labels: {
+      title: 'Confirm Deletion',
+      message: 'Are you sure you want to delete invoice #XM9141? This action cannot be undone.',
+      cancel: 'Cancel',
+      delete: 'Delete',
+    },
+    onCancel: fn(),
+    onConfirm: fn(),
+  },
+} satisfies Meta<typeof DeleteInvoiceDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/src/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog.tsx
+++ b/frontend/src/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog.tsx
@@ -1,0 +1,102 @@
+/**
+ * @name DeleteInvoiceDialog
+ * @author Tyrell Curry <tyrellcurryio@gmail.com>
+ *
+ * Centered confirmation modal for deleting an invoice. Presentation only: it
+ * renders the copy passed via `labels` and calls back on cancel/confirm. Fades
+ * in on open and out on close (or backdrop click / Escape).
+ *
+ * @param props - see {@link IDeleteInvoiceDialogProps}
+ *
+ * @returns {JSX.Element}
+ */
+'use client';
+
+import { JSX, useEffect, useState } from 'react';
+import classNames from 'classnames';
+import Button from '@/components/ui/button/button';
+import Container from '@/components/ui/container/container';
+import Flex from '@/components/ui/flex/flex';
+import Text from '@/components/ui/text/text';
+import { IDeleteInvoiceDialogProps } from '@/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog.types';
+
+const DeleteInvoiceDialog = (props: IDeleteInvoiceDialogProps): JSX.Element => {
+  const { open, labels, onCancel, onConfirm } = props;
+
+  // Kept true while the close animation plays, so the dialog can fade out before
+  // the container is hidden.
+  const [isMounted, setIsMounted] = useState(open);
+  if (open && !isMounted) {
+    setIsMounted(true);
+  }
+
+  // Close on Escape while open.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onCancel();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onCancel]);
+
+  return (
+    <Container
+      aria-hidden={!open}
+      className={classNames(
+        'fixed inset-0 z-50 flex items-center justify-center p-6',
+        open || isMounted ? 'visible' : 'invisible',
+        open ? 'pointer-events-auto' : 'pointer-events-none'
+      )}
+    >
+      {/* Backdrop */}
+      <Container
+        className={classNames(
+          'absolute inset-0 bg-black/50 transition-opacity duration-200',
+          open ? 'opacity-100' : 'opacity-0'
+        )}
+        aria-hidden
+        onClick={onCancel}
+      />
+
+      {/* Dialog */}
+      <Flex
+        as="section"
+        direction="col"
+        gapY={3}
+        role="alertdialog"
+        className={classNames(
+          'relative z-10 w-full max-w-[480px] rounded-lg bg-white dark:bg-blue-03 p-8 md:p-12 shadow-[0px_10px_10px_-10px_rgba(72,84,159,0.1)] transition duration-200',
+          open ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+        )}
+        aria-modal
+        onTransitionEnd={() => {
+          if (!open) {
+            setIsMounted(false);
+          }
+        }}
+      >
+        <Text className="text-gray-08 dark:text-white" tag={'h2'} variant="h2">
+          {labels.title}
+        </Text>
+        <Text
+          className="text-gray-06 dark:text-gray-05 leading-[22px]"
+          tag={'p'}
+          variant="body-alt"
+        >
+          {labels.message}
+        </Text>
+        <Flex align="center" className="mt-4" gapX={2} justify="end">
+          <Button label={labels.cancel} type="button" variant="secondary" onClick={onCancel} />
+          <Button label={labels.delete} type="button" variant="danger" onClick={onConfirm} />
+        </Flex>
+      </Flex>
+    </Container>
+  );
+};
+
+export default DeleteInvoiceDialog;

--- a/frontend/src/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog.types.ts
+++ b/frontend/src/features/invoices/components/delete-invoice-dialog/delete-invoice-dialog.types.ts
@@ -1,0 +1,14 @@
+export interface DeleteInvoiceDialogLabels {
+  title: string;
+  /** Full confirmation message, with the invoice id already interpolated. */
+  message: string;
+  cancel: string;
+  delete: string;
+}
+
+export interface IDeleteInvoiceDialogProps {
+  open: boolean;
+  labels: DeleteInvoiceDialogLabels;
+  onCancel: () => void;
+  onConfirm: () => void;
+}


### PR DESCRIPTION
Adds a confirmation modal for deleting an invoice, wired to the Delete button on the invoice detail view.

## Changes
- New DeleteInvoiceDialog feature component: a centered modal (title, message, Cancel / Delete) over a dimmed backdrop, matching the Figma. Presentation only, with copy passed via labels. Fades and scales in on open and out on close, and closes on backdrop click or Escape.
- Storybook story under Features/Invoices and a DeleteInvoice i18n namespace (the message interpolates the invoice id).
- Clicking Delete opens the dialog; confirming navigates back to the list with deletion left as a @TODO for the future api layer, and canceling closes it.

Verified with lint, types, tests, next build and storybook build.