### PR TITLE
fix(text): apply text variant styles correctly

### DIFF
--- a/frontend/src/styles/ui/text.css
+++ b/frontend/src/styles/ui/text.css
@@ -1,27 +1,27 @@
 @layer components {
   .text {
     @apply text-left;
-    /* Text Variants */
-    &--h1 {
-      @apply font-bold text-[36px] tracking-[-1px];
-    }
-    &--h2 {
-      @apply font-bold text-[28px] tracking-[-0.75px];
-    }
-    &--h3 {
-      @apply font-bold text-[20px] tracking-[-0.25px];
-    }
-    &--kicker {
-      @apply font-bold text-[18px] tracking-[-0.25px];
-    }
-    &--body {
-      @apply text-[18px] tracking-[-0.1px];
-    }
-    &--body-alt {
-      @apply font-medium leading-[20px] text-[18px] tracking-[-0.1px];
-    }
-    &--rich {
-      @apply text-[18px] tracking-[-0.1px];
-    }
+  }
+  /* Text Variants */
+  .text--h1 {
+    @apply font-bold text-[36px] tracking-[-1px];
+  }
+  .text--h2 {
+    @apply font-bold text-[28px] tracking-[-0.75px];
+  }
+  .text--h3 {
+    @apply font-bold text-[20px] tracking-[-0.25px];
+  }
+  .text--kicker {
+    @apply font-bold text-[18px] tracking-[-0.25px];
+  }
+  .text--body {
+    @apply text-[18px] tracking-[-0.1px];
+  }
+  .text--body-alt {
+    @apply font-medium leading-[20px] text-[18px] tracking-[-0.1px];
+  }
+  .text--rich {
+    @apply text-[18px] tracking-[-0.1px];
   }
 }


### PR DESCRIPTION
Fixes the Text component variants (h1, h2, h3, kicker, body, body-alt, rich) not applying their styles.

text.css defined the variants with SCSS-style nesting (.text { &--h2 { ... } }), which does not concatenate in Tailwind v4's native CSS nesting pipeline: every variant collapsed to a bare .text rule, so headings and other variants rendered without their intended size and weight. Flattened them to explicit .text--* selectors (same fix previously applied to button.css).

This was visible in Storybook but affected the whole app. Verified the compiled CSS now contains each .text--* rule and only a single .text base rule.