### PR TITLE
fix: refine mobile responsive layouts across invoice views

### DIFF
--- a/frontend/src/components/layouts/main-menu/__snapshots__/main-menu.snapshot.test.tsx.snap
+++ b/frontend/src/components/layouts/main-menu/__snapshots__/main-menu.snapshot.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Main Menu Component renders correctly with default props 1`] = `
         class="btn btn--custom h-fit self-center"
       >
         <svg
-          class="icon w-8 h-8 fill-gray-07 hover:fill-gray-05"
+          class="icon w-7 h-7 max-h-7 md:w-8 md:h-8 md:max-h-8 fill-gray-07 hover:fill-gray-05"
         />
       </button>
       <hr
@@ -33,7 +33,7 @@ exports[`Main Menu Component renders correctly with default props 1`] = `
       >
         <img
           alt="lorem ipsum"
-          class="rounded-full w-full h-auto max-w-8"
+          class="rounded-full w-full h-auto max-w-10 min-w-7"
           data-nimg="1"
           decoding="async"
           height="64"

--- a/frontend/src/components/layouts/main-menu/main-menu.tsx
+++ b/frontend/src/components/layouts/main-menu/main-menu.tsx
@@ -27,7 +27,7 @@ const MainMenu = (props: IMainMenuProps): JSX.Element => {
           aria-label={darkmode === DARK_MODE ? darkmodeBtn?.lightAria : darkmodeBtn?.darkAria}
           className="h-fit self-center"
           iconLeft={darkmode === DARK_MODE ? 'dm-sun' : 'dm-moon'}
-          iconLeftClassName="w-8 h-8 fill-gray-07 hover:fill-gray-05"
+          iconLeftClassName="w-7 h-7 max-h-7 md:w-8 md:h-8 md:max-h-8 fill-gray-07 hover:fill-gray-05"
           variant="custom"
           onClick={darkmodeToggle}
         />
@@ -39,7 +39,7 @@ const MainMenu = (props: IMainMenuProps): JSX.Element => {
         >
           <Image
             alt={profile?.profileImageAlt}
-            className="rounded-full w-full h-auto max-w-8"
+            className="rounded-full w-full h-auto max-w-10 min-w-7"
             height={64}
             src={!!profile?.profileImage ? profile?.profileImage : '/assets/profile-default.png'}
             width={64}

--- a/frontend/src/features/invoices/components/invoice-bar/__snapshots__/invoice-bar.snapshot.test.tsx.snap
+++ b/frontend/src/features/invoices/components/invoice-bar/__snapshots__/invoice-bar.snapshot.test.tsx.snap
@@ -3,10 +3,12 @@
 exports[`Invoice Bar Component renders correctly with filled props 1`] = `
 <div>
   <menu
-    class="flex flex-row items-center justify-between"
+    class="flex flex-row items-center justify-between flex-wrap gap-y-6 md:flex-nowrap md:gap-y-0"
     data-testid="snapshot"
   >
-    <div>
+    <div
+      class="order-1"
+    >
       <h2
         class="text text--h2 text-gray-08 dark:text-white"
       >
@@ -28,10 +30,10 @@ exports[`Invoice Bar Component renders correctly with filled props 1`] = `
       </p>
     </div>
     <div
-      class="flex flex-row items-center gap-x-[18px] md:gap-x-10"
+      class="contents md:flex md:items-center md:gap-x-10"
     >
       <div
-        class="grid relative place-items-center"
+        class="grid items-center relative order-3 w-full justify-items-start md:order-none md:w-auto md:justify-items-center"
       >
         <button
           class="btn btn--custom flex items-center gap-x-3 font-bold text-xl dark:text-gray-05"
@@ -54,7 +56,7 @@ exports[`Invoice Bar Component renders correctly with filled props 1`] = `
         </button>
       </div>
       <button
-        class="btn base btn--primary p-[6px] md:p-2 gap-x-2 items-center pr-[15px] text-xl md:text-lg"
+        class="btn base btn--primary order-2 p-[6px] md:order-none md:p-2 gap-x-2 items-center pr-[15px] text-xl md:text-lg"
       >
         <svg
           class="icon min-w-8 min-h-8 max-h-8 max-h-8"

--- a/frontend/src/features/invoices/components/invoice-bar/invoice-bar.tsx
+++ b/frontend/src/features/invoices/components/invoice-bar/invoice-bar.tsx
@@ -37,8 +37,14 @@ const InvoiceBar = (props: IInvoiceBarProps): JSX.Element => {
   const filterKeys: (keyof FilterState)[] = ['draft', 'pending', 'paid'];
 
   return (
-    <Flex align="center" as="menu" justify="between" {...rest}>
-      <Container>
+    <Flex
+      align="center"
+      as="menu"
+      className="flex-wrap gap-y-6 md:flex-nowrap md:gap-y-0"
+      justify="between"
+      {...rest}
+    >
+      <Container className="order-1">
         <Text className="text-gray-08 dark:text-white" tag={'h2'} variant="h2">
           {invoiceBarTitle}
         </Text>
@@ -47,8 +53,11 @@ const InvoiceBar = (props: IInvoiceBarProps): JSX.Element => {
           <span className="hidden md:block">{totalInvoicesText?.desktop}</span>
         </Text>
       </Container>
-      <Flex align="center" className="gap-x-[18px] md:gap-x-10">
-        <Grid className="relative place-items-center">
+      <Container className="contents md:flex md:items-center md:gap-x-10">
+        <Grid
+          align="center"
+          className="relative order-3 w-full justify-items-start md:order-none md:w-auto md:justify-items-center"
+        >
           <Button
             className="flex items-center gap-x-3 font-bold text-xl dark:text-gray-05"
             iconRight={'chevron-down'}
@@ -84,7 +93,7 @@ const InvoiceBar = (props: IInvoiceBarProps): JSX.Element => {
           )}
         </Grid>
         <Button
-          className="p-[6px] md:p-2 gap-x-2 items-center pr-[15px] text-xl md:text-lg"
+          className="order-2 p-[6px] md:order-none md:p-2 gap-x-2 items-center pr-[15px] text-xl md:text-lg"
           iconLeft={'circle-plus'}
           iconLeftClassName="min-w-8 min-h-8 max-h-8 max-h-8"
           variant="primary"
@@ -96,7 +105,7 @@ const InvoiceBar = (props: IInvoiceBarProps): JSX.Element => {
           }
           onClick={newInvoiceHandler}
         />
-      </Flex>
+      </Container>
     </Flex>
   );
 };

--- a/frontend/src/features/invoices/components/invoice-details/invoice-details.tsx
+++ b/frontend/src/features/invoices/components/invoice-details/invoice-details.tsx
@@ -71,10 +71,27 @@ const InvoiceDetails = (props: IInvoiceDetailsProps): JSX.Element => {
   const statusStyles = getInvoiceStatusStyles(invoiceStatus);
 
   const actions = (
-    <Flex align="center" gapX={2}>
-      <Button label={labels.edit} variant="secondary" onClick={onEdit} />
-      <Button label={labels.delete} variant="danger" onClick={onDelete} />
-      <Button label={labels.markAsPaid} variant="primary" onClick={onMarkAsPaid} />
+    <Flex align="center" className="md:flex-row md:gap-x-2" direction="col" gap={2}>
+      <Flex className="w-full md:contents" gapX={2}>
+        <Button
+          className="flex-1 justify-center md:flex-none"
+          label={labels.edit}
+          variant="secondary"
+          onClick={onEdit}
+        />
+        <Button
+          className="flex-1 justify-center md:flex-none"
+          label={labels.delete}
+          variant="danger"
+          onClick={onDelete}
+        />
+      </Flex>
+      <Button
+        className="w-full justify-center md:w-fit"
+        label={labels.markAsPaid}
+        variant="primary"
+        onClick={onMarkAsPaid}
+      />
     </Flex>
   );
 

--- a/frontend/src/features/invoices/components/invoice-form-drawer/invoice-form-drawer.tsx
+++ b/frontend/src/features/invoices/components/invoice-form-drawer/invoice-form-drawer.tsx
@@ -177,7 +177,7 @@ const InvoiceFormDrawer = (props: IInvoiceFormDrawerProps): JSX.Element => {
         </Text>
 
         <form
-          className="flex-1 overflow-y-auto px-6 md:px-12"
+          className="flex-1 overflow-y-auto px-6 md:px-12 pb-8"
           id="invoice-form"
           onSubmit={(event) => {
             event.preventDefault();
@@ -402,42 +402,78 @@ const InvoiceFormDrawer = (props: IInvoiceFormDrawerProps): JSX.Element => {
         </form>
 
         {/* Footer */}
-        <Flex
-          align="center"
-          className="px-6 md:px-12 py-6 shadow-[0_-10px_10px_-10px_rgba(72,84,159,0.1)]"
-          gapX={2}
-          justify={mode === 'edit' ? 'end' : 'between'}
-        >
+        <Container className="px-6 md:px-12 py-6 shadow-[0_-10px_10px_-10px_rgba(72,84,159,0.1)]">
           {mode === 'edit' ? (
-            <>
-              <Button label={labels.cancel} type="button" variant="secondary" onClick={onClose} />
+            <Flex className="md:justify-end" gap={2}>
               <Button
+                className="flex-1 justify-center md:flex-none"
+                label={labels.cancel}
+                type="button"
+                variant="secondary"
+                onClick={onClose}
+              />
+              <Button
+                className="flex-1 justify-center md:flex-none"
                 form="invoice-form"
                 label={labels.saveChanges}
                 type="submit"
                 variant="primary"
               />
-            </>
+            </Flex>
           ) : (
             <>
-              <Button label={labels.discard} type="button" variant="secondary" onClick={onClose} />
-              <Flex align="center" gapX={2}>
+              {/* Mobile: Discard + Save as Draft on one row, Save & Send full width */}
+              <Flex className="md:hidden" direction="col" gap={2}>
+                <Flex gapX={2}>
+                  <Button
+                    className="flex-1 justify-center"
+                    label={labels.discard}
+                    type="button"
+                    variant="secondary"
+                    onClick={onClose}
+                  />
+                  <Button
+                    className="flex-1 justify-center"
+                    label={labels.saveAsDraft}
+                    type="button"
+                    variant="dark"
+                    onClick={() => onSaveDraft?.(values)}
+                  />
+                </Flex>
                 <Button
-                  label={labels.saveAsDraft}
-                  type="button"
-                  variant="dark"
-                  onClick={() => onSaveDraft?.(values)}
-                />
-                <Button
+                  className="w-full justify-center"
                   form="invoice-form"
                   label={labels.saveAndSend}
                   type="submit"
                   variant="primary"
                 />
               </Flex>
+              {/* Desktop: Discard left, save actions right */}
+              <Flex align="center" className="hidden md:flex" justify="between">
+                <Button
+                  label={labels.discard}
+                  type="button"
+                  variant="secondary"
+                  onClick={onClose}
+                />
+                <Flex align="center" gapX={2}>
+                  <Button
+                    label={labels.saveAsDraft}
+                    type="button"
+                    variant="dark"
+                    onClick={() => onSaveDraft?.(values)}
+                  />
+                  <Button
+                    form="invoice-form"
+                    label={labels.saveAndSend}
+                    type="submit"
+                    variant="primary"
+                  />
+                </Flex>
+              </Flex>
             </>
           )}
-        </Flex>
+        </Container>
       </Flex>
     </Container>
   );

--- a/frontend/src/features/invoices/components/invoice/__snapshots__/invoice.snapshot.test.tsx.snap
+++ b/frontend/src/features/invoices/components/invoice/__snapshots__/invoice.snapshot.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Invoice Component renders correctly with data passed to props 1`] = `
           RT3080
         </p>
         <p
-          class="text text--body text-gray-07 flex gap-1 dark:text-gray-05"
+          class="text text--body text-gray-07 flex gap-1 whitespace-nowrap dark:text-gray-05"
         >
           <span
             class="text text--body text-gray-06 dark:text-gray-05"

--- a/frontend/src/features/invoices/components/invoice/desktop-view.tsx
+++ b/frontend/src/features/invoices/components/invoice/desktop-view.tsx
@@ -41,7 +41,7 @@ const DesktopView = (props: IInvoiceProps): JSX.Element => {
             </Text>
             {invoiceId}
           </Text>
-          <Text className="text-gray-07 flex gap-1 dark:text-gray-05" tag={'p'}>
+          <Text className="text-gray-07 flex gap-1 whitespace-nowrap dark:text-gray-05" tag={'p'}>
             <Text className="text-gray-06 dark:text-gray-05" tag={'span'}>
               {dueText}
             </Text>


### PR DESCRIPTION
Mobile and responsive layout adjustments across the invoice views.

## Changes
- Invoice detail actions: on mobile, Edit and Delete sit on one row with Mark as Paid full width beneath; unchanged inline row on desktop. Same treatment applied to the invoice form drawer footer (create mode groups the secondary actions with the primary action full width on mobile).
- Home invoice bar: on mobile the filter drops to its own row underneath the total and New Invoice button, left aligned. Desktop is unchanged.
- Light/dark mode toggle icon is capped at 28px on mobile (32px on desktop).
- Added bottom padding under the Item List so the fixed footer no longer crowds the Add New Item button, on both desktop and mobile.
- Desktop invoice row: stop the Due column (e.g. Due 19 Aug 2021) from wrapping.
- Includes a small profile image sizing tweak in the main menu.

Verified with lint, types, 92 tests (snapshots regenerated), next build and storybook build.